### PR TITLE
Fix react native open function crash app

### DIFF
--- a/packages/authgear-react-native/src/index.ts
+++ b/packages/authgear-react-native/src/index.ts
@@ -15,6 +15,7 @@ import { generateCodeVerifier, computeCodeChallenge } from "./pkce";
 import { openURL, openAuthorizeURL } from "./nativemodule";
 import { getCallbackURLScheme } from "./url";
 import { getAnonymousJWK, signAnonymousJWT } from "./jwt";
+import URL from 'core-js-pure/features/url';
 export * from "@authgear/core";
 
 /**
@@ -149,11 +150,21 @@ export class ReactNativeContainer<
 
   // eslint-disable-next-line class-methods-use-this
   async openURL(url: string): Promise<void> {
+    // validate url to avoid error in native code
+    const urlObj = new URL(url);
+    if (urlObj.protocol !== "http:" && urlObj.protocol !== "https:") {
+      throw new Error("Only allows http / https scheme")
+    }
     await openURL(url);
   }
 
   async open(page: Page): Promise<void> {
-    await this.openURL(page);
+    const {endpoint} = this.apiClient
+    if (endpoint == null) {
+      throw new Error("Endpoint cannot be undefined, please double check whether you have run configure()")
+    }
+    const endpointWithoutTrailingSlash = endpoint.replace(/\/$/, "")
+    await this.openURL(`${endpointWithoutTrailingSlash}${page}`);
   }
 
   /**


### PR DESCRIPTION
fix #31

TODO: in iOS, ASAuthenticationSession is used for openURL, so when user call `authgear.open(Page.Settings)` for example, the dialog with message `{appName} want to use {domain} to sign in ...` is shown (ref https://github.com/authgear/authgear-sdk-ios/issues/24). Should change to use `SFSafariViewController` instead
 
