### PR TITLE
Use SFSafariViewController for openURL function

### DIFF
--- a/packages/authgear-react-native/android/src/main/java/com/authgear/reactnative/AuthgearReactNativeModule.java
+++ b/packages/authgear-react-native/android/src/main/java/com/authgear/reactnative/AuthgearReactNativeModule.java
@@ -74,8 +74,9 @@ public class AuthgearReactNativeModule extends ReactContextBaseJavaModule implem
         }
     }
 
+    // prefersSFSafariViewController is used by iOS app only
     @ReactMethod
-    public void openURL(String urlString, Promise promise) {
+    public void openURL(String urlString, Boolean prefersSFSafariViewController, Promise promise) {
         try {
             Activity currentActivity = getCurrentActivity();
             if (currentActivity == null) {
@@ -96,8 +97,9 @@ public class AuthgearReactNativeModule extends ReactContextBaseJavaModule implem
         }
     }
 
+    // prefersSFSafariViewController is used by iOS app only
     @ReactMethod
-    public void openAuthorizeURL(String urlString, String scheme, Promise promise) {
+    public void openAuthorizeURL(String urlString, String scheme, Boolean prefersSFSafariViewController, Promise promise) {
         this.openURLPromise = promise;
 
         try {

--- a/packages/authgear-react-native/ios/AGAuthgearReactNative.m
+++ b/packages/authgear-react-native/ios/AGAuthgearReactNative.m
@@ -108,10 +108,11 @@ RCT_EXPORT_METHOD(dismiss:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseReje
 }
 
 RCT_EXPORT_METHOD(openURL:(NSURL *)url
+                  prefersSFSafariViewController:(BOOL)prefersSFSafariViewController
                   resolve:(RCTPromiseResolveBlock)resolve
                    reject:(RCTPromiseRejectBlock)reject)
 {
-    if (@available(iOS 12.0, *)) {
+    if (@available(iOS 12.0, *) && !prefersSFSafariViewController) {
         self.asSession = [[ASWebAuthenticationSession alloc] initWithURL:url
                                                        callbackURLScheme:nil
                                                        completionHandler:^(NSURL *url, NSError *error) {
@@ -130,7 +131,7 @@ RCT_EXPORT_METHOD(openURL:(NSURL *)url
                 resolve(nil);
             }
         }
-    } else if (@available(iOS 11.0, *)) {
+    } else if (@available(iOS 11.0, *) && !prefersSFSafariViewController) {
         self.sfSession = [[SFAuthenticationSession alloc] initWithURL:url
                                                     callbackURLScheme:nil
                                                     completionHandler:^(NSURL *url, NSError *error){
@@ -149,6 +150,7 @@ RCT_EXPORT_METHOD(openURL:(NSURL *)url
     } else if (@available(iOS 9.0, *)) {
         SFSafariViewController *vc = [[SFSafariViewController alloc] initWithURL:url];
         vc.delegate = self;
+        vc.modalPresentationStyle = UIModalPresentationPageSheet;
         self.sfViewController = vc;
         UIViewController *rootViewController = RCTPresentedViewController();
         [rootViewController presentViewController:vc animated:YES completion:nil];
@@ -160,13 +162,14 @@ RCT_EXPORT_METHOD(openURL:(NSURL *)url
 
 RCT_EXPORT_METHOD(openAuthorizeURL:(NSURL *)url
                             scheme:(NSString *)scheme
+      prefersSFSafariViewController:(BOOL)prefersSFSafariViewController
                            resolve:(RCTPromiseResolveBlock)resolve
                             reject:(RCTPromiseRejectBlock)reject)
 {
     self.openURLResolve = resolve;
     self.openURLReject = reject;
 
-    if (@available(iOS 12.0, *)) {
+    if (@available(iOS 12.0, *) && !prefersSFSafariViewController) {
         self.asSession = [[ASWebAuthenticationSession alloc] initWithURL:url
                                                                             callbackURLScheme:scheme
                                                                             completionHandler:^(NSURL *url, NSError *error) {
@@ -191,7 +194,7 @@ RCT_EXPORT_METHOD(openAuthorizeURL:(NSURL *)url
             self.asSession.presentationContextProvider = self;
         }
         [self.asSession start];
-    } else if (@available(iOS 11.0, *)) {
+    } else if (@available(iOS 11.0, *) && !prefersSFSafariViewController) {
         self.sfSession = [[SFAuthenticationSession alloc] initWithURL:url
                                                                       callbackURLScheme:scheme
                                                                       completionHandler:^(NSURL *url, NSError *error) {
@@ -216,6 +219,7 @@ RCT_EXPORT_METHOD(openAuthorizeURL:(NSURL *)url
     } else if (@available(iOS 9.0, *)) {
         SFSafariViewController *vc = [[SFSafariViewController alloc] initWithURL:url];
         vc.delegate = self;
+        vc.modalPresentationStyle = UIModalPresentationPageSheet;
         self.sfViewController = vc;
         UIViewController *rootViewController = RCTPresentedViewController();
         [rootViewController presentViewController:vc animated:YES completion:nil];

--- a/packages/authgear-react-native/src/nativemodule.ts
+++ b/packages/authgear-react-native/src/nativemodule.ts
@@ -11,18 +11,23 @@ export async function sha256String(input: string): Promise<number[]> {
   return AuthgearReactNative.sha256String(input);
 }
 
-export async function openURL(url: string): Promise<void> {
-  return AuthgearReactNative.openURL(url);
+export async function openURL(
+  url: string,
+  prefersSFSafariViewController: boolean
+): Promise<void> {
+  return AuthgearReactNative.openURL(url, prefersSFSafariViewController);
 }
 
 export async function openAuthorizeURL(
   url: string,
-  callbackURLScheme: string
+  callbackURLScheme: string,
+  prefersSFSafariViewController: boolean
 ): Promise<string> {
   try {
     const redirectURI = await AuthgearReactNative.openAuthorizeURL(
       url,
-      callbackURLScheme
+      callbackURLScheme,
+      prefersSFSafariViewController
     );
     await dismiss();
     return redirectURI;


### PR DESCRIPTION
closes https://github.com/authgear/authgear-sdk-ios/issues/14

in react native, iOS, `ASAuthenticationSession` is used for openURL, so when user call `authgear.open`(Page.Settings) for example, the dialog with message `{appName} want to use {domain} to sign in ...` is shown (ref authgear/authgear-sdk-ios#24). Changed to use SFSafariViewController instead