### PR TITLE
Configure build on appcenter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,5 @@ dist/
 
 xcuserdata/
 xcshareddata/
+!**/reactNativeExample.xcodeproj/xcshareddata/
 temp/

--- a/example/reactnative/.gitignore
+++ b/example/reactnative/.gitignore
@@ -24,6 +24,7 @@ DerivedData
 # Android/IntelliJ
 #
 build/
+release/
 .idea
 .gradle
 local.properties

--- a/example/reactnative/android/app/build.gradle
+++ b/example/reactnative/android/app/build.gradle
@@ -156,9 +156,6 @@ android {
             signingConfig signingConfigs.debug
         }
         release {
-            // Caution! In production, you need to generate your own keystore file.
-            // see https://reactnative.dev/docs/signed-apk-android.
-            signingConfig signingConfigs.debug
             minifyEnabled enableProguardInReleaseBuilds
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
         }

--- a/example/reactnative/appcenter-post-clone.sh
+++ b/example/reactnative/appcenter-post-clone.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# install dependencies for React Native SDK
+cd ../../packages/authgear-react-native
+npm install
+popd
+# install dependencies for Web SDK
+cd ../../packages/authgear-web
+npm install
+popd
+# to SDK project root
+cd ../..
+# install dependencies
+npm install
+# build authgear JS SDK
+npm run build

--- a/example/reactnative/ios/reactNativeExample.xcodeproj/xcshareddata/xcschemes/reactNativeExample.xcscheme
+++ b/example/reactnative/ios/reactNativeExample.xcodeproj/xcshareddata/xcschemes/reactNativeExample.xcscheme
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1130"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "13B07F861A680F5B00A75B9A"
+               BuildableName = "reactNativeExample.app"
+               BlueprintName = "reactNativeExample"
+               ReferencedContainer = "container:reactNativeExample.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "00E356ED1AD99517003FC87E"
+               BuildableName = "reactNativeExampleTests.xctest"
+               BlueprintName = "reactNativeExampleTests"
+               ReferencedContainer = "container:reactNativeExample.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "13B07F861A680F5B00A75B9A"
+            BuildableName = "reactNativeExample.app"
+            BlueprintName = "reactNativeExample"
+            ReferencedContainer = "container:reactNativeExample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "13B07F861A680F5B00A75B9A"
+            BuildableName = "reactNativeExample.app"
+            BlueprintName = "reactNativeExample"
+            ReferencedContainer = "container:reactNativeExample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/packages/authgear-react-native/package-lock.json
+++ b/packages/authgear-react-native/package-lock.json
@@ -4,6 +4,10 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@authgear/core": {
+      "version": "file:../authgear-core",
+      "dev": true
+    },
     "@react-native-async-storage/async-storage": {
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.13.2.tgz",

--- a/packages/authgear-react-native/package.json
+++ b/packages/authgear-react-native/package.json
@@ -11,7 +11,7 @@
     "android"
   ],
   "devDependencies": {
-    "@authgear/core": "0.2.0",
+    "@authgear/core": "file:../authgear-core",
     "@react-native-async-storage/async-storage": "1.13.2",
     "@types/react-native": "0.60.25",
     "core-js-pure": "3.6.5"

--- a/packages/authgear-web/package-lock.json
+++ b/packages/authgear-web/package-lock.json
@@ -3,5 +3,10 @@
   "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
-  "dependencies": {}
+  "dependencies": {
+    "@authgear/core": {
+      "version": "file:../authgear-core",
+      "dev": true
+    }
+  }
 }

--- a/packages/authgear-web/package.json
+++ b/packages/authgear-web/package.json
@@ -10,6 +10,6 @@
     "dist/authgear-web.cjs.js"
   ],
   "devDependencies": {
-    "@authgear/core": "0.2.0"
+    "@authgear/core": "file:../authgear-core"
   }
 }


### PR DESCRIPTION
require #30 

For android the build is successful but cannot release due to the following error

```
==============================================================================
Task         : App Center distribute
Description  : Distribute app builds to testers and ***s via Visual Studio App Center
Version      : 3.173.0
Author       : Microsoft Corporation
Help         : https://docs.microsoft.com/azure/devops/pipelines/tasks/deploy/app-center-distribute
==============================================================================
(node:3024) Warning: Use Cipheriv for counter mode of aes-256-ctr
...
##[warning]Cannot find any file based on /Users/runner/work/1/a/mapping/**/mapping.txt.
##[error]Error: Failed find: ENOENT: no such file or directory, stat '/Users/runner/work/1/s/example/reactnative/node_modules/@authgear/react-native/node_modules/@authgear/core'
##[section]Finishing: Create distribution
##[section]Starting: Checkout authgear-sdk-js@ci-test to s
==============================================================================
```