### PR TITLE
Fix failed to refresh access token twice

### DIFF
--- a/packages/authgear-core/src/container.ts
+++ b/packages/authgear-core/src/container.ts
@@ -126,7 +126,9 @@ export abstract class BaseContainer<T extends BaseAPIClient> {
     const { access_token, refresh_token, expires_in } = response;
 
     this.accessToken = access_token;
-    this.refreshToken = refresh_token;
+    if (refresh_token) {
+      this.refreshToken = refresh_token;
+    }
     this.expireAt = new Date(
       new Date(Date.now()).getTime() + expires_in * EXPIRE_IN_PERCENTAGE * 1000
     );


### PR DESCRIPTION
refs authgear/authgear-server#970

Token response will not have refresh token if the request is using the
refreshing the access token. So we should check if there is refresh token,
before updating the refresh token in memory.