### PR TITLE
Update `authgear.open` api

### DIFF
--- a/packages/authgear-react-native/src/index.ts
+++ b/packages/authgear-react-native/src/index.ts
@@ -419,6 +419,8 @@ export class ReactNativeContainer {
 
   /**
    * Open the URL with the user agent authenticated with current user.
+   *
+   * @internal
    */
 
   // eslint-disable-next-line class-methods-use-this

--- a/packages/authgear-web/src/container.ts
+++ b/packages/authgear-web/src/container.ts
@@ -392,7 +392,11 @@ export class WebContainer {
       });
     }
 
-    window.location.href = targetURL;
+    if (options?.openInSameTab) {
+      window.location.href = targetURL;
+    } else {
+      window.open(targetURL, "_blank");
+    }
   }
 
   async open(page: Page, options?: SettingOptions): Promise<void> {

--- a/packages/authgear-web/src/container.ts
+++ b/packages/authgear-web/src/container.ts
@@ -361,6 +361,8 @@ export class WebContainer {
 
   /**
    * Open the URL with the user agent authenticated with current user.
+   *
+   * @internal
    */
   async openURL(url: string, options?: SettingOptions): Promise<void> {
     const u = new URL(url);

--- a/packages/authgear-web/src/types.ts
+++ b/packages/authgear-web/src/types.ts
@@ -104,6 +104,11 @@ export interface SettingOptions {
    * UI locale tags
    */
   uiLocales?: string[];
+
+  /**
+   * Indicates whether to open the settings page in the same tab
+   */
+  openInSameTab?: boolean;
 }
 
 /**


### PR DESCRIPTION
ref #206 

- Open in new tab by default
- Allow calling `authgear.open` when session type is cookie
- Mark openURL as internal api