### PR TITLE
Update webapp demo and setup multiple endpoints for testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ deploy-docs: docs
 
 .PHONY: build-image
 build-image:
-	docker build --tag $(IMAGE) --file ./example/reactweb/Dockerfile .
+	docker build --platform linux/x86-64 --tag $(IMAGE) --file ./example/reactweb/Dockerfile .
 
 .PHONY: push-image
 push-image:

--- a/all-in-one.yaml
+++ b/all-in-one.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     kubernetes.io/tls-acme: "true"
 spec:
+  ingressClassName: nginx
   tls:
   - secretName: authgear-demo-webapp-cookie-app1-tls
     hosts:
@@ -28,6 +29,7 @@ metadata:
   annotations:
     kubernetes.io/tls-acme: "true"
 spec:
+  ingressClassName: nginx
   tls:
   - secretName: authgear-demo-webapp-cookie-app2-tls
     hosts:
@@ -51,6 +53,7 @@ metadata:
   annotations:
     kubernetes.io/tls-acme: "true"
 spec:
+  ingressClassName: nginx
   tls:
   - secretName: authgear-token-app1-tls
     hosts:
@@ -74,6 +77,7 @@ metadata:
   annotations:
     kubernetes.io/tls-acme: "true"
 spec:
+  ingressClassName: nginx
   tls:
   - secretName: authgear-token-app2-tls
     hosts:
@@ -97,6 +101,7 @@ metadata:
   annotations:
     kubernetes.io/tls-acme: "true"
 spec:
+  ingressClassName: nginx
   tls:
   - secretName: web-tls
     hosts:

--- a/all-in-one.yaml
+++ b/all-in-one.yaml
@@ -1,6 +1,98 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
+  name: authgear-demo-webapp-cookie-app1
+  annotations:
+    kubernetes.io/tls-acme: "true"
+spec:
+  tls:
+  - secretName: authgear-demo-webapp-cookie-app1-tls
+    hosts:
+    - cookie-app1.authgear-demo-webapp.pandawork.com
+  rules:
+  - host: cookie-app1.authgear-demo-webapp.pandawork.com
+    http:
+      paths:
+      - path: /
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: authgear-demo-webapp
+            port:
+              name: http
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: authgear-demo-webapp-cookie-app2
+  annotations:
+    kubernetes.io/tls-acme: "true"
+spec:
+  tls:
+  - secretName: authgear-demo-webapp-cookie-app2-tls
+    hosts:
+    - cookie-app2.authgear-demo-webapp.pandawork.com
+  rules:
+  - host: cookie-app2.authgear-demo-webapp.pandawork.com
+    http:
+      paths:
+      - path: /
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: authgear-demo-webapp
+            port:
+              name: http
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: authgear-token-app1
+  annotations:
+    kubernetes.io/tls-acme: "true"
+spec:
+  tls:
+  - secretName: authgear-token-app1-tls
+    hosts:
+    - token-app1.authgear.pandawork.com
+  rules:
+  - host: token-app1.authgear.pandawork.com
+    http:
+      paths:
+      - path: /
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: authgear-demo-webapp
+            port:
+              name: http
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: authgear-token-app2
+  annotations:
+    kubernetes.io/tls-acme: "true"
+spec:
+  tls:
+  - secretName: authgear-token-app2-tls
+    hosts:
+    - token-app2.authgear.pandawork.com
+  rules:
+  - host: token-app2.authgear.pandawork.com
+    http:
+      paths:
+      - path: /
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: authgear-demo-webapp
+            port:
+              name: http
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
   name: authgear-demo-webapp
   annotations:
     kubernetes.io/tls-acme: "true"
@@ -50,7 +142,7 @@ spec:
     spec:
       containers:
       - name: authgear-demo-webapp
-        image: quay.io/theauthgear/authgear-demo-webapp:git-f4f9f003abe0
+        image: quay.io/theauthgear/authgear-demo-webapp:git-9e0e550e5cba
         ports:
         - name: http
           containerPort: 80

--- a/all-in-one.yaml
+++ b/all-in-one.yaml
@@ -1,17 +1,17 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: authgear-demo-webapp-cookie-app1
+  name: authgear-qa-app-cookie-app1
   annotations:
     kubernetes.io/tls-acme: "true"
 spec:
   ingressClassName: nginx
   tls:
-  - secretName: authgear-demo-webapp-cookie-app1-tls
+  - secretName: authgear-qa-app-cookie-app1-tls
     hosts:
-    - cookie-app1.authgear-demo-webapp.pandawork.com
+    - cookie-app1.authgear-qa-app.pandawork.com
   rules:
-  - host: cookie-app1.authgear-demo-webapp.pandawork.com
+  - host: cookie-app1.authgear-qa-app.pandawork.com
     http:
       paths:
       - path: /
@@ -25,17 +25,17 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: authgear-demo-webapp-cookie-app2
+  name: authgear-qa-app-cookie-app2
   annotations:
     kubernetes.io/tls-acme: "true"
 spec:
   ingressClassName: nginx
   tls:
-  - secretName: authgear-demo-webapp-cookie-app2-tls
+  - secretName: authgear-qa-app-cookie-app2-tls
     hosts:
-    - cookie-app2.authgear-demo-webapp.pandawork.com
+    - cookie-app2.authgear-qa-app.pandawork.com
   rules:
-  - host: cookie-app2.authgear-demo-webapp.pandawork.com
+  - host: cookie-app2.authgear-qa-app.pandawork.com
     http:
       paths:
       - path: /

--- a/example/reactweb/Dockerfile
+++ b/example/reactweb/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.13.2 as build
+FROM node:16.14-bullseye as build
 WORKDIR /project
 COPY . .
 RUN npm ci && npm run bundle:web-module


### PR DESCRIPTION
For cookie-based testing:

- https://cookie-app1.authgear-demo-webapp.pandawork.com/
- https://cookie-app2.authgear-demo-webapp.pandawork.com/

For token-based testing

- https://token-app1.authgear.pandawork.com/
- https://token-app2.authgear.pandawork.com/
