### PR TITLE
add README for each SDK package

### DIFF
--- a/packages/authgear-capacitor/README.md
+++ b/packages/authgear-capacitor/README.md
@@ -1,0 +1,19 @@
+# Authgear SDK for Capacitor (Ionic)
+
+With the Authgear SDK for Capacitor, you can easily integrate authentication features into your Ionic app. In most cases, it involves just a few lines of code to enable multiple authentication methods, such as social logins, passwordless, biometrics logins, one-time-password (OTP) with SMS/WhatsApp, and multi-factor authentication (MFA).
+
+## What is Authgear?
+Authgear is a highly adaptable identity-as-a-service (IDaaS) platform for web and mobile applications. Authgear makes user authentication easier and faster to implement by integrating it into various types of applications - from single-page web apps to mobile applications to API services.
+
+### Key Features
+- Zero trust authentication architecture with OpenID Connect (OIDC) standard.
+- Easy-to-use interfaces for user registration and login, including email, phone, username as login ID, and password, OTP, magic links, etc for authentication.
+- Support a wide range of identity providers, such as Google, Apple, and Azure Active Directory (AD).
+- Support biometric login on mobile, Passkeys, and Multi-Factor Authentication (MFA) such as SMS/email-based verification and authenticator apps with TOTP.
+
+## Getting Started
+- Install the package:
+```npm install @authgear/capacitor```
+
+- Create a free [Authgear account](https://www.authgear.com/)
+- See usage examples from our [Ionic Getting Started guide](https://docs.authgear.com/get-started/native-mobile-app/ionic-sdk).

--- a/packages/authgear-react-native/README.md
+++ b/packages/authgear-react-native/README.md
@@ -1,0 +1,19 @@
+# Authgear SDK for React Native
+
+The Authgear SDK for React Native makes it ease to integrate authentication features into your React Native application. In most cases, it involves just a few lines of code to enable multiple authentication methods, such as social logins, passwordless, biometrics logins, one-time-password (OTP) with SMS/WhatsApp, and multi-factor authentication (MFA).
+
+## What is Authgear?
+Authgear is a highly adaptable identity-as-a-service (IDaaS) platform for web and mobile applications. Authgear makes user authentication easier and faster to implement by integrating it into various types of applications - from single-page web apps to mobile applications to API services.
+
+### Key Features
+- Zero trust authentication architecture with OpenID Connect (OIDC) standard.
+- Easy-to-use interfaces for user registration and login, including email, phone, username as login ID, and password, OTP, magic links, etc for authentication.
+- Support a wide range of identity providers, such as Google, Apple, and Azure Active Directory (AD).
+- Support biometric login on mobile, Passkeys, and Multi-Factor Authentication (MFA) such as SMS/email-based verification and authenticator apps with TOTP.
+
+## Getting Started
+- Install the package:
+```npm install @authgear/react-native```
+
+- Create a free [Authgear account](https://www.authgear.com/)
+- See usage examples from our [React Native Getting Started guide](https://docs.authgear.com/get-started/native-mobile-app/react-native).

--- a/packages/authgear-web/README.md
+++ b/packages/authgear-web/README.md
@@ -1,0 +1,19 @@
+# Authgear SDK for Single Page Applications (SPA)
+
+With Authgear SDK for Single Page Applications (SPA), you can easily integrate authentication features into your app (Angular, Vue, React, or any JavaScript websites). In most cases, it involves just a few lines of code to enable multiple authentication methods, such as social logins, passwordless, biometrics logins, one-time-password (OTP) with SMS/WhatsApp, and multi-factor authentication (MFA).
+
+## What is Authgear?
+Authgear is a highly adaptable identity-as-a-service (IDaaS) platform for web and mobile applications. Authgear makes user authentication easier and faster to implement by integrating it into various types of applications - from single-page web apps to mobile applications to API services.
+
+### Key Features
+- Zero trust authentication architecture with OpenID Connect (OIDC) standard.
+- Easy-to-use interfaces for user registration and login, including email, phone, username as login ID, and password, OTP, magic links, etc for authentication.
+- Support a wide range of identity providers, such as Google, Apple, and Azure Active Directory (AD).
+- Support biometric login on mobile, Passkeys, and Multi-Factor Authentication (MFA) such as SMS/email-based verification and authenticator apps with TOTP.
+
+## Getting Started
+- Install the package:
+```npm install @authgear/web```
+
+- Create a free [Authgear account](https://www.authgear.com/)
+- See usage examples from our [Getting Started guide](https://docs.authgear.com/get-started/single-page-app).


### PR DESCRIPTION
At the moment, Authgear JavaScript packages have no README.md on https://www.npmjs.com.

I've included README for each package under `authgear-sdk-js/packages`
<img width="1470" alt="SCR-20240307-nmje" src="https://github.com/authgear/authgear-sdk-js/assets/16970059/2185cec4-ae33-4ae5-b082-9f9d6b6236ee">
