### PR TITLE
Implement app-initiated-sso-to-web

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
 nodejs 20.9.0
 yarn 1.22.22
 kubectl 1.21.8
-ruby 3.3.0
+ruby 2.7.5

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
 nodejs 20.9.0
 yarn 1.22.22
 kubectl 1.21.8
-ruby 2.7.5
+ruby 3.3.3

--- a/example/capacitor/README.md
+++ b/example/capacitor/README.md
@@ -28,6 +28,8 @@ Then, in this directory, run the exmaple app.
 ```sh
 cd example/capacitor
 npm i
+# Build the example app
+npm run build
 # Run it in ios device
 npm run run-ios
 # OR, run it in android device

--- a/example/capacitor/ios/App/Podfile.lock
+++ b/example/capacitor/ios/App/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - AuthgearCapacitor (2.4.1):
+  - AuthgearCapacitor (2.9.0):
     - Capacitor
   - Capacitor (5.6.0):
     - CapacitorCordova
@@ -39,7 +39,7 @@ EXTERNAL SOURCES:
     :path: "../../node_modules/@capacitor/status-bar"
 
 SPEC CHECKSUMS:
-  AuthgearCapacitor: af2f1d6b3fd23b8de85301d83fcd63d84dd57c61
+  AuthgearCapacitor: f49cb5a509f8d7c5fa16a3256daf0ed85e6c7c8c
   Capacitor: ebfc16cdb8116d04c101686b080342872da42d43
   CapacitorApp: 024e1b1bea5f883d79f6330d309bc441c88ad04a
   CapacitorCordova: 931b48fcdbc9bc985fc2f16cec9f77c794a27729
@@ -49,4 +49,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: a539d41cba947136121a5fa89cd9506a49f45a31
 
-COCOAPODS: 1.14.3
+COCOAPODS: 1.15.2

--- a/example/capacitor/package.json
+++ b/example/capacitor/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview",
     "test.unit": "vitest",
     "lint": "eslint",
+    "sync": "cap sync",
     "run-ios": "cap run ios",
     "run-android": "cap run android"
   },

--- a/example/capacitor/src/pages/Home.tsx
+++ b/example/capacitor/src/pages/Home.tsx
@@ -119,7 +119,7 @@ function AuthgearDemo() {
   });
   const [biometricEnabled, setBiometricEnabled] = useState<boolean>(false);
 
-  const [isAppInitiatedSSOToWebEnabled, setIsAppInitiatedSSOToWebEnabled] =
+  const [preAuthenticatedURLEnabled, setIsAppInitiatedSSOToWebEnabled] =
     useState(() => {
       return readIsAppInitiatedSSOToWebEnabled();
     });
@@ -218,7 +218,7 @@ function AuthgearDemo() {
       writeEndpoint(endpoint);
       writeIsSSOEnabled(isSSOEnabled);
       writeUseWebKitWebView(useWebKitWebView);
-      writeIsAppInitiatedSSOToWebEnabled(isAppInitiatedSSOToWebEnabled);
+      writeIsAppInitiatedSSOToWebEnabled(preAuthenticatedURLEnabled);
       writeAppInitiatedSSOToWebClientID(appInitiatedSSOToWebClientID);
       writeAppInitiatedSSOToWebRedirectURI(appInitiatedSSOToWebRedirectURI);
 
@@ -245,7 +245,7 @@ function AuthgearDemo() {
               })
             : undefined,
           isSSOEnabled,
-          isAppInitiatedSSOToWebEnabled,
+          preAuthenticatedURLEnabled,
         });
       }
       await postConfigure();
@@ -259,7 +259,7 @@ function AuthgearDemo() {
     endpoint,
     isSSOEnabled,
     useWebKitWebView,
-    isAppInitiatedSSOToWebEnabled,
+    preAuthenticatedURLEnabled,
     appInitiatedSSOToWebClientID,
     appInitiatedSSOToWebRedirectURI,
     postConfigure,
@@ -862,7 +862,7 @@ function AuthgearDemo() {
           <>
             <IonToggle
               className="toggle"
-              checked={isAppInitiatedSSOToWebEnabled}
+              checked={preAuthenticatedURLEnabled}
               onIonChange={onChangeIsAppInitiatedSSOToWebEnabled}
             >
               Is App Initiated SSO To Web Enabled
@@ -941,7 +941,7 @@ function AuthgearDemo() {
               !initialized ||
               loading ||
               !loggedIn ||
-              !isAppInitiatedSSOToWebEnabled
+              !preAuthenticatedURLEnabled
             }
             onClick={onClickAppInitiatedSSOToWeb}
           >

--- a/example/capacitor/src/pages/Home.tsx
+++ b/example/capacitor/src/pages/Home.tsx
@@ -49,18 +49,18 @@ import authgearCapacitor, {
   DeviceBrowserUIImplementation,
 } from "@authgear/capacitor";
 import {
-  readAppInitiatedSSOToWebClientID,
-  readAppInitiatedSSOToWebRedirectURI,
+  readPreAuthenticatedURLClientID,
+  readPreAuthenticatedURLRedirectURI,
   readClientID,
   readEndpoint,
-  readIsAppInitiatedSSOToWebEnabled,
+  readIsPreAuthenticatedURLEnabled,
   readIsSSOEnabled,
   readUseWebKitWebView,
-  writeAppInitiatedSSOToWebClientID,
-  writeAppInitiatedSSOToWebRedirectURI,
+  writePreAuthenticatedURLClientID,
+  writePreAuthenticatedURLRedirectURI,
   writeClientID,
   writeEndpoint,
-  writeIsAppInitiatedSSOToWebEnabled,
+  writeIsPreAuthenticatedURLEnabled,
   writeIsSSOEnabled,
   writeUseWebKitWebView,
 } from "../storage";
@@ -119,19 +119,19 @@ function AuthgearDemo() {
   });
   const [biometricEnabled, setBiometricEnabled] = useState<boolean>(false);
 
-  const [preAuthenticatedURLEnabled, setIsAppInitiatedSSOToWebEnabled] =
+  const [preAuthenticatedURLEnabled, setIsPreAuthenticatedURLEnabled] =
     useState(() => {
-      return readIsAppInitiatedSSOToWebEnabled();
+      return readIsPreAuthenticatedURLEnabled();
     });
 
-  const [appInitiatedSSOToWebClientID, setAppInitiatedSSOToWebClientID] =
+  const [preAuthenticatedURLClientID, setPreAuthenticatedURLClientID] =
     useState(() => {
-      return readAppInitiatedSSOToWebClientID();
+      return readPreAuthenticatedURLClientID();
     });
 
-  const [appInitiatedSSOToWebRedirectURI, setAppInitiatedSSOToWebRedirectURI] =
+  const [preAuthenticatedURLRedirectURI, setPreAuthenticatedURLRedirectURI] =
     useState(() => {
-      return readAppInitiatedSSOToWebRedirectURI();
+      return readPreAuthenticatedURLRedirectURI();
     });
 
   const [sessionState, setSessionState] = useState<SessionState | null>(() => {
@@ -218,9 +218,9 @@ function AuthgearDemo() {
       writeEndpoint(endpoint);
       writeIsSSOEnabled(isSSOEnabled);
       writeUseWebKitWebView(useWebKitWebView);
-      writeIsAppInitiatedSSOToWebEnabled(preAuthenticatedURLEnabled);
-      writeAppInitiatedSSOToWebClientID(appInitiatedSSOToWebClientID);
-      writeAppInitiatedSSOToWebRedirectURI(appInitiatedSSOToWebRedirectURI);
+      writeIsPreAuthenticatedURLEnabled(preAuthenticatedURLEnabled);
+      writePreAuthenticatedURLClientID(preAuthenticatedURLClientID);
+      writePreAuthenticatedURLRedirectURI(preAuthenticatedURLRedirectURI);
 
       if (isPlatformWeb()) {
         await authgearWeb.configure({
@@ -260,8 +260,8 @@ function AuthgearDemo() {
     isSSOEnabled,
     useWebKitWebView,
     preAuthenticatedURLEnabled,
-    appInitiatedSSOToWebClientID,
-    appInitiatedSSOToWebRedirectURI,
+    preAuthenticatedURLClientID,
+    preAuthenticatedURLRedirectURI,
     postConfigure,
     useTransientTokenStorage,
     showError,
@@ -340,15 +340,15 @@ function AuthgearDemo() {
     }
   }, [showError, updateBiometricState]);
 
-  const startAppInitiatedSSOToWeb = useCallback(async () => {
-    const shouldUseAnotherBrowser = appInitiatedSSOToWebRedirectURI !== "";
+  const startPreAuthenticatedURL = useCallback(async () => {
+    const shouldUseAnotherBrowser = preAuthenticatedURLRedirectURI !== "";
     let targetRedirectURI = REDIRECT_URI_CAPACITOR;
     let targetClientID = clientID;
-    if (appInitiatedSSOToWebRedirectURI !== "") {
-      targetRedirectURI = appInitiatedSSOToWebRedirectURI;
+    if (preAuthenticatedURLRedirectURI !== "") {
+      targetRedirectURI = preAuthenticatedURLRedirectURI;
     }
-    if (appInitiatedSSOToWebClientID !== "") {
-      targetClientID = appInitiatedSSOToWebClientID;
+    if (preAuthenticatedURLClientID !== "") {
+      targetClientID = preAuthenticatedURLClientID;
     }
     setLoading(true);
     try {
@@ -366,7 +366,7 @@ function AuthgearDemo() {
         });
         // Then start a auth to prove it is working
         const newContainer = new CapacitorContainer({
-          name: "appInitiatedSSOToWeb",
+          name: "preAuthenticatedURL",
         });
         await newContainer.configure({
           endpoint: endpoint,
@@ -381,7 +381,7 @@ function AuthgearDemo() {
         const userInfo = await newContainer.fetchUserInfo();
         showUserInfo(userInfo);
       } else {
-        // This willbe redirected to appInitiatedSSOToWebRedirectURI and never close,
+        // This willbe redirected to preAuthenticatedURLRedirectURI and never close,
         // so we do not await
         uiImpl
           .openAuthorizationURL({
@@ -398,8 +398,8 @@ function AuthgearDemo() {
       setLoading(false);
     }
   }, [
-    appInitiatedSSOToWebClientID,
-    appInitiatedSSOToWebRedirectURI,
+    preAuthenticatedURLClientID,
+    preAuthenticatedURLRedirectURI,
     clientID,
     endpoint,
     showError,
@@ -626,23 +626,23 @@ function AuthgearDemo() {
     []
   );
 
-  const onChangeIsAppInitiatedSSOToWebEnabled = useCallback(
+  const onChangeIsPreAuthenticatedURLEnabled = useCallback(
     (e: IonToggleCustomEvent<ToggleChangeEventDetail<unknown>>) => {
-      setIsAppInitiatedSSOToWebEnabled(e.detail.checked);
+      setIsPreAuthenticatedURLEnabled(e.detail.checked);
     },
     []
   );
 
-  const onChangeAppInitiatedSSOToWebClientID = useCallback(
+  const onChangePreAuthenticatedURLClientID = useCallback(
     (e: IonInputCustomEvent<InputInputEventDetail>) => {
-      setAppInitiatedSSOToWebClientID(e.detail.value ?? "");
+      setPreAuthenticatedURLClientID(e.detail.value ?? "");
     },
     []
   );
 
-  const onChangeAppInitiatedSSOToWebRedirectURI = useCallback(
+  const onChangePreAuthenticatedURLRedirectURI = useCallback(
     (e: IonInputCustomEvent<InputInputEventDetail>) => {
-      setAppInitiatedSSOToWebRedirectURI(e.detail.value ?? "");
+      setPreAuthenticatedURLRedirectURI(e.detail.value ?? "");
     },
     []
   );
@@ -714,14 +714,14 @@ function AuthgearDemo() {
     [authenticateBiometric]
   );
 
-  const onClickAppInitiatedSSOToWeb = useCallback(
+  const onClickPreAuthenticatedURL = useCallback(
     (e: MouseEvent<HTMLIonButtonElement>) => {
       e.preventDefault();
       e.stopPropagation();
 
-      startAppInitiatedSSOToWeb();
+      startPreAuthenticatedURL();
     },
-    [startAppInitiatedSSOToWeb]
+    [startPreAuthenticatedURL]
   );
 
   const onClickDisableBiometric = useCallback(
@@ -784,7 +784,7 @@ function AuthgearDemo() {
     [logout]
   );
 
-  const canUseAppInitiatedSSOToWeb = !isPlatformWeb();
+  const canUsePreAuthenticatedURL = !isPlatformWeb();
 
   return (
     <>
@@ -858,28 +858,28 @@ function AuthgearDemo() {
           <IonLabel>Session State</IonLabel>
           <IonNote>{sessionState}</IonNote>
         </div>
-        {!canUseAppInitiatedSSOToWeb ? null : (
+        {!canUsePreAuthenticatedURL ? null : (
           <>
             <IonToggle
               className="toggle"
               checked={preAuthenticatedURLEnabled}
-              onIonChange={onChangeIsAppInitiatedSSOToWebEnabled}
+              onIonChange={onChangeIsPreAuthenticatedURLEnabled}
             >
-              Is App Initiated SSO To Web Enabled
+              Is Pre Authenticated URL Enabled
             </IonToggle>
             <IonInput
               type="text"
-              label="App Initiated SSO To Web Client ID"
+              label="Pre Authenticated URL Client ID"
               placeholder="Enter Client ID"
-              onIonInput={onChangeAppInitiatedSSOToWebClientID}
-              value={appInitiatedSSOToWebClientID}
+              onIonInput={onChangePreAuthenticatedURLClientID}
+              value={preAuthenticatedURLClientID}
             />
             <IonInput
               type="text"
-              label="App Initiated SSO To Web Redirect URI"
+              label="Pre Authenticated URL Redirect URI"
               placeholder="Enter URI"
-              onIonInput={onChangeAppInitiatedSSOToWebRedirectURI}
-              value={appInitiatedSSOToWebRedirectURI}
+              onIonInput={onChangePreAuthenticatedURLRedirectURI}
+              value={preAuthenticatedURLRedirectURI}
             />
           </>
         )}
@@ -934,7 +934,7 @@ function AuthgearDemo() {
         >
           Authenticate with biometric
         </IonButton>
-        {!canUseAppInitiatedSSOToWeb ? null : (
+        {!canUsePreAuthenticatedURL ? null : (
           <IonButton
             className="button"
             disabled={
@@ -943,9 +943,9 @@ function AuthgearDemo() {
               !loggedIn ||
               !preAuthenticatedURLEnabled
             }
-            onClick={onClickAppInitiatedSSOToWeb}
+            onClick={onClickPreAuthenticatedURL}
           >
-            App Initiated SSO To Web
+            Pre Authenticated URL
           </IonButton>
         )}
         <IonButton

--- a/example/capacitor/src/pages/Home.tsx
+++ b/example/capacitor/src/pages/Home.tsx
@@ -48,12 +48,18 @@ import authgearCapacitor, {
   WebKitWebViewUIImplementation,
 } from "@authgear/capacitor";
 import {
+  readAppInitiatedSSOToWebClientID,
+  readAppInitiatedSSOToWebRedirectURI,
   readClientID,
   readEndpoint,
+  readIsAppInitiatedSSOToWebEnabled,
   readIsSSOEnabled,
   readUseWebKitWebView,
+  writeAppInitiatedSSOToWebClientID,
+  writeAppInitiatedSSOToWebRedirectURI,
   writeClientID,
   writeEndpoint,
+  writeIsAppInitiatedSSOToWebEnabled,
   writeIsSSOEnabled,
   writeUseWebKitWebView,
 } from "../storage";
@@ -111,6 +117,20 @@ function AuthgearDemo() {
     return readUseWebKitWebView();
   });
   const [biometricEnabled, setBiometricEnabled] = useState<boolean>(false);
+
+  const [isAppInitiatedSSOToWebEnabled, setIsAppInitiatedSSOToWebEnabled] =
+    useState(() => {
+      return readIsAppInitiatedSSOToWebEnabled();
+    });
+  const [appInitiatedSSOToWebRedirectURI, setAppInitiatedSSOToWebRedirectURI] =
+    useState(() => {
+      return readAppInitiatedSSOToWebRedirectURI();
+    });
+
+  const [appInitiatedSSOToWebClientID, setAppInitiatedSSOToWebClientID] =
+    useState(() => {
+      return readAppInitiatedSSOToWebClientID();
+    });
 
   const [sessionState, setSessionState] = useState<SessionState | null>(() => {
     if (isPlatformWeb()) {
@@ -196,6 +216,9 @@ function AuthgearDemo() {
       writeEndpoint(endpoint);
       writeIsSSOEnabled(isSSOEnabled);
       writeUseWebKitWebView(useWebKitWebView);
+      writeIsAppInitiatedSSOToWebEnabled(isAppInitiatedSSOToWebEnabled);
+      writeAppInitiatedSSOToWebRedirectURI(appInitiatedSSOToWebRedirectURI);
+      writeAppInitiatedSSOToWebClientID(appInitiatedSSOToWebClientID);
 
       if (isPlatformWeb()) {
         await authgearWeb.configure({
@@ -220,6 +243,7 @@ function AuthgearDemo() {
               })
             : undefined,
           isSSOEnabled,
+          isAppInitiatedSSOToWebEnabled,
         });
       }
       await postConfigure();
@@ -233,8 +257,11 @@ function AuthgearDemo() {
     endpoint,
     isSSOEnabled,
     useWebKitWebView,
-    useTransientTokenStorage,
+    isAppInitiatedSSOToWebEnabled,
+    appInitiatedSSOToWebRedirectURI,
+    appInitiatedSSOToWebClientID,
     postConfigure,
+    useTransientTokenStorage,
     showError,
   ]);
 
@@ -531,6 +558,27 @@ function AuthgearDemo() {
     []
   );
 
+  const onChangeIsAppInitiatedSSOToWebEnabled = useCallback(
+    (e: IonToggleCustomEvent<ToggleChangeEventDetail<unknown>>) => {
+      setIsAppInitiatedSSOToWebEnabled(e.detail.checked);
+    },
+    []
+  );
+
+  const onChangeAppInitiatedSSOToWebRedirectURI = useCallback(
+    (e: IonInputCustomEvent<InputInputEventDetail>) => {
+      setAppInitiatedSSOToWebRedirectURI(e.detail.value ?? "");
+    },
+    []
+  );
+
+  const onChangeAppInitiatedSSOToWebClientID = useCallback(
+    (e: IonInputCustomEvent<InputInputEventDetail>) => {
+      setAppInitiatedSSOToWebClientID(e.detail.value ?? "");
+    },
+    []
+  );
+
   const onChangeUseWebKitWebView = useCallback(
     (e: IonToggleCustomEvent<ToggleChangeEventDetail<unknown>>) => {
       setUseWebKitWebView(e.detail.checked);
@@ -730,6 +778,27 @@ function AuthgearDemo() {
           <IonLabel>Session State</IonLabel>
           <IonNote>{sessionState}</IonNote>
         </div>
+        <IonToggle
+          className="toggle"
+          checked={isAppInitiatedSSOToWebEnabled}
+          onIonChange={onChangeIsAppInitiatedSSOToWebEnabled}
+        >
+          Is App Initiated SSO To Web Enabled
+        </IonToggle>
+        <IonInput
+          type="text"
+          label="App Initiated SSO To Web Redirect URI"
+          placeholder="Enter App Initiated SSO To Web Redirect URI"
+          onIonInput={onChangeAppInitiatedSSOToWebRedirectURI}
+          value={endpoint}
+        />
+        <IonInput
+          type="text"
+          label="App Initiated SSO To Web Client ID"
+          placeholder="Enter App Initiated SSO To Web Client ID"
+          onIonInput={onChangeAppInitiatedSSOToWebClientID}
+          value={endpoint}
+        />
         <IonButton
           className="button"
           disabled={loading}

--- a/example/capacitor/src/pages/Home.tsx
+++ b/example/capacitor/src/pages/Home.tsx
@@ -353,8 +353,8 @@ function AuthgearDemo() {
     setLoading(true);
     try {
       const url = await authgearCapacitor.makePreAuthenticatedURL({
-        clientID: targetClientID,
-        redirectURI: targetRedirectURI,
+        webApplicationClientID: targetClientID,
+        webApplicationURI: targetRedirectURI,
       });
       const uiImpl = new WebKitWebViewUIImplementation();
       if (!shouldUseAnotherBrowser) {

--- a/example/capacitor/src/pages/Home.tsx
+++ b/example/capacitor/src/pages/Home.tsx
@@ -809,7 +809,7 @@ function AuthgearDemo() {
             <IonInput
               type="text"
               label="App Initiated SSO To Web Client ID"
-              placeholder="Enter App Initiated SSO To Web Client ID"
+              placeholder="Enter Client ID"
               onIonInput={onChangeAppInitiatedSSOToWebClientID}
               value={endpoint}
             />

--- a/example/capacitor/src/pages/Home.tsx
+++ b/example/capacitor/src/pages/Home.tsx
@@ -358,7 +358,7 @@ function AuthgearDemo() {
       });
       const uiImpl = new WebKitWebViewUIImplementation();
       if (!shouldUseAnotherBrowser) {
-        // Use device browser to open the url and set the cookie
+        // Use webkit webview to open the url and set the cookie
         await uiImpl.openAuthorizationURL({
           url: url,
           redirectURI: REDIRECT_URI_CAPACITOR,

--- a/example/capacitor/src/pages/Home.tsx
+++ b/example/capacitor/src/pages/Home.tsx
@@ -811,7 +811,7 @@ function AuthgearDemo() {
               label="App Initiated SSO To Web Client ID"
               placeholder="Enter Client ID"
               onIonInput={onChangeAppInitiatedSSOToWebClientID}
-              value={endpoint}
+              value={appInitiatedSSOToWebClientID}
             />
           </>
         )}
@@ -872,7 +872,7 @@ function AuthgearDemo() {
             disabled={
               !initialized ||
               loading ||
-              loggedIn ||
+              !loggedIn ||
               !isAppInitiatedSSOToWebEnabled
             }
             onClick={onClickAppInitiatedSSOToWeb}

--- a/example/capacitor/src/pages/Home.tsx
+++ b/example/capacitor/src/pages/Home.tsx
@@ -352,7 +352,7 @@ function AuthgearDemo() {
     }
     setLoading(true);
     try {
-      const url = await authgearCapacitor.makeAppInitiatedSSOToWebURL({
+      const url = await authgearCapacitor.makePreAuthenticatedURL({
         clientID: targetClientID,
         redirectURI: targetRedirectURI,
       });

--- a/example/capacitor/src/storage.ts
+++ b/example/capacitor/src/storage.ts
@@ -33,13 +33,6 @@ export function readIsAppInitiatedSSOToWebEnabled(): boolean {
   return false;
 }
 
-export function readAppInitiatedSSOToWebRedirectURI(): string {
-  const str = window.localStorage.getItem(
-    "authgear.appInitiatedSSOToWebRedirectURI"
-  );
-  return str ?? "";
-}
-
 export function readUseWebKitWebView(): boolean {
   const str = window.localStorage.getItem("authgear.useWebKitWebView");
   if (str === "true") {
@@ -72,10 +65,6 @@ export function writeIsAppInitiatedSSOToWebEnabled(isEnabled: boolean) {
     "authgear.isAppInitiatedSSOToWebEnabled",
     String(isEnabled)
   );
-}
-
-export function writeAppInitiatedSSOToWebRedirectURI(uri: string) {
-  window.localStorage.setItem("authgear.appInitiatedSSOToWebRedirectURI", uri);
 }
 
 export function writeUseWebKitWebView(useWebKitWebView: boolean) {

--- a/example/capacitor/src/storage.ts
+++ b/example/capacitor/src/storage.ts
@@ -16,21 +16,21 @@ export function readIsSSOEnabled(): boolean {
   return false;
 }
 
-export function readAppInitiatedSSOToWebClientID(): string {
+export function readPreAuthenticatedURLClientID(): string {
   const str = window.localStorage.getItem(
-    "authgear.appInitiatedSSOToWebClientID"
+    "authgear.preAuthenticatedURLClientID"
   );
   return str ?? "";
 }
 
-export function readAppInitiatedSSOToWebRedirectURI(): string {
+export function readPreAuthenticatedURLRedirectURI(): string {
   const str = window.localStorage.getItem(
-    "authgear.appInitiatedSSOToWebRedirectURI"
+    "authgear.preAuthenticatedURLRedirectURI"
   );
   return str ?? "";
 }
 
-export function readIsAppInitiatedSSOToWebEnabled(): boolean {
+export function readIsPreAuthenticatedURLEnabled(): boolean {
   const str = window.localStorage.getItem(
     "authgear.preAuthenticatedURLEnabled"
   );
@@ -60,18 +60,15 @@ export function writeIsSSOEnabled(isSSOEnabled: boolean) {
   window.localStorage.setItem("authgear.isSSOEnabled", String(isSSOEnabled));
 }
 
-export function writeAppInitiatedSSOToWebClientID(clientID: string) {
-  window.localStorage.setItem(
-    "authgear.appInitiatedSSOToWebClientID",
-    clientID
-  );
+export function writePreAuthenticatedURLClientID(clientID: string) {
+  window.localStorage.setItem("authgear.preAuthenticatedURLClientID", clientID);
 }
 
-export function writeAppInitiatedSSOToWebRedirectURI(uri: string) {
-  window.localStorage.setItem("authgear.appInitiatedSSOToWebRedirectURI", uri);
+export function writePreAuthenticatedURLRedirectURI(uri: string) {
+  window.localStorage.setItem("authgear.preAuthenticatedURLRedirectURI", uri);
 }
 
-export function writeIsAppInitiatedSSOToWebEnabled(isEnabled: boolean) {
+export function writeIsPreAuthenticatedURLEnabled(isEnabled: boolean) {
   window.localStorage.setItem(
     "authgear.preAuthenticatedURLEnabled",
     String(isEnabled)

--- a/example/capacitor/src/storage.ts
+++ b/example/capacitor/src/storage.ts
@@ -16,6 +16,30 @@ export function readIsSSOEnabled(): boolean {
   return false;
 }
 
+export function readAppInitiatedSSOToWebClientID(): string {
+  const str = window.localStorage.getItem(
+    "authgear.appInitiatedSSOToWebClientID"
+  );
+  return str ?? "";
+}
+
+export function readIsAppInitiatedSSOToWebEnabled(): boolean {
+  const str = window.localStorage.getItem(
+    "authgear.isAppInitiatedSSOToWebEnabled"
+  );
+  if (str === "true") {
+    return true;
+  }
+  return false;
+}
+
+export function readAppInitiatedSSOToWebRedirectURI(): string {
+  const str = window.localStorage.getItem(
+    "authgear.appInitiatedSSOToWebRedirectURI"
+  );
+  return str ?? "";
+}
+
 export function readUseWebKitWebView(): boolean {
   const str = window.localStorage.getItem("authgear.useWebKitWebView");
   if (str === "true") {
@@ -34,6 +58,24 @@ export function writeEndpoint(endpoint: string) {
 
 export function writeIsSSOEnabled(isSSOEnabled: boolean) {
   window.localStorage.setItem("authgear.isSSOEnabled", String(isSSOEnabled));
+}
+
+export function writeAppInitiatedSSOToWebClientID(clientID: string) {
+  window.localStorage.setItem(
+    "authgear.appInitiatedSSOToWebClientID",
+    clientID
+  );
+}
+
+export function writeIsAppInitiatedSSOToWebEnabled(isEnabled: boolean) {
+  window.localStorage.setItem(
+    "authgear.isAppInitiatedSSOToWebEnabled",
+    String(isEnabled)
+  );
+}
+
+export function writeAppInitiatedSSOToWebRedirectURI(uri: string) {
+  window.localStorage.setItem("authgear.appInitiatedSSOToWebRedirectURI", uri);
 }
 
 export function writeUseWebKitWebView(useWebKitWebView: boolean) {

--- a/example/capacitor/src/storage.ts
+++ b/example/capacitor/src/storage.ts
@@ -32,7 +32,7 @@ export function readAppInitiatedSSOToWebRedirectURI(): string {
 
 export function readIsAppInitiatedSSOToWebEnabled(): boolean {
   const str = window.localStorage.getItem(
-    "authgear.isAppInitiatedSSOToWebEnabled"
+    "authgear.preAuthenticatedURLEnabled"
   );
   if (str === "true") {
     return true;
@@ -73,7 +73,7 @@ export function writeAppInitiatedSSOToWebRedirectURI(uri: string) {
 
 export function writeIsAppInitiatedSSOToWebEnabled(isEnabled: boolean) {
   window.localStorage.setItem(
-    "authgear.isAppInitiatedSSOToWebEnabled",
+    "authgear.preAuthenticatedURLEnabled",
     String(isEnabled)
   );
 }

--- a/example/capacitor/src/storage.ts
+++ b/example/capacitor/src/storage.ts
@@ -23,6 +23,13 @@ export function readAppInitiatedSSOToWebClientID(): string {
   return str ?? "";
 }
 
+export function readAppInitiatedSSOToWebRedirectURI(): string {
+  const str = window.localStorage.getItem(
+    "authgear.appInitiatedSSOToWebRedirectURI"
+  );
+  return str ?? "";
+}
+
 export function readIsAppInitiatedSSOToWebEnabled(): boolean {
   const str = window.localStorage.getItem(
     "authgear.isAppInitiatedSSOToWebEnabled"
@@ -58,6 +65,10 @@ export function writeAppInitiatedSSOToWebClientID(clientID: string) {
     "authgear.appInitiatedSSOToWebClientID",
     clientID
   );
+}
+
+export function writeAppInitiatedSSOToWebRedirectURI(uri: string) {
+  window.localStorage.setItem("authgear.appInitiatedSSOToWebRedirectURI", uri);
 }
 
 export function writeIsAppInitiatedSSOToWebEnabled(isEnabled: boolean) {

--- a/example/reactnative/src/screens/MainScreen.tsx
+++ b/example/reactnative/src/screens/MainScreen.tsx
@@ -585,7 +585,7 @@ const HomeScreen: React.FC = () => {
       });
       const uiImpl = new WebKitWebViewUIImplementation();
       if (!shouldUseAnotherBrowser) {
-        // Use device browser to open the url and set the cookie
+        // Use webkit webview to open the url and set the cookie
         await uiImpl.openAuthorizationURL({
           url: url,
           redirectURI: redirectURI,

--- a/example/reactnative/src/screens/MainScreen.tsx
+++ b/example/reactnative/src/screens/MainScreen.tsx
@@ -579,7 +579,7 @@ const HomeScreen: React.FC = () => {
       targetClientID = appInitiatedSSOToWebClientID;
     }
     try {
-      const url = await authgear.makeAppInitiatedSSOToWebURL({
+      const url = await authgear.makePreAuthenticatedURL({
         clientID: targetClientID,
         redirectURI: targetRedirectURI,
       });

--- a/example/reactnative/src/screens/MainScreen.tsx
+++ b/example/reactnative/src/screens/MainScreen.tsx
@@ -33,7 +33,6 @@ import authgear, {
   BiometricAccessConstraintAndroid,
   SessionState,
   WebKitWebViewUIImplementation,
-  DeviceBrowserUIImplementation,
 } from '@authgear/react-native';
 import RadioGroup, {RadioGroupItemProps} from '../RadioGroup';
 
@@ -161,11 +160,11 @@ const HomeScreen: React.FC = () => {
   const [useWebKitWebView, setUseWebKitWebView] = useState(false);
   const [biometricEnabled, setBiometricEnabled] = useState<boolean>(false);
 
-  const [preAuthenticatedURLEnabled, setIsAppInitiatedSSOToWebEnabled] =
+  const [preAuthenticatedURLEnabled, setIsPreAuthenticatedURLEnabled] =
     useState(false);
-  const [appInitiatedSSOToWebClientID, setAppInitiatedSSOToWebClientID] =
+  const [preAuthenticatedURLClientID, setPreAuthenticatedURLClientID] =
     useState('');
-  const [appInitiatedSSOToWebRedirectURI, setAppInitiatedSSOToWebRedirectURI] =
+  const [preAuthenticatedURLRedirectURI, setPreAuthenticatedURLRedirectURI] =
     useState('');
 
   const [userInfo, setUserInfo] = useState<UserInfo | null>(null);
@@ -567,16 +566,16 @@ const HomeScreen: React.FC = () => {
       });
   }, [showError, updateBiometricState]);
 
-  const startAppInitiatedSSOToWeb = useCallback(async () => {
+  const startPreAuthenticatedURL = useCallback(async () => {
     setLoading(true);
-    const shouldUseAnotherBrowser = appInitiatedSSOToWebRedirectURI !== '';
+    const shouldUseAnotherBrowser = preAuthenticatedURLRedirectURI !== '';
     let targetRedirectURI = redirectURI;
     let targetClientID = clientID;
-    if (appInitiatedSSOToWebRedirectURI !== '') {
-      targetRedirectURI = appInitiatedSSOToWebRedirectURI;
+    if (preAuthenticatedURLRedirectURI !== '') {
+      targetRedirectURI = preAuthenticatedURLRedirectURI;
     }
-    if (appInitiatedSSOToWebClientID !== '') {
-      targetClientID = appInitiatedSSOToWebClientID;
+    if (preAuthenticatedURLClientID !== '') {
+      targetClientID = preAuthenticatedURLClientID;
     }
     try {
       const url = await authgear.makePreAuthenticatedURL({
@@ -593,7 +592,7 @@ const HomeScreen: React.FC = () => {
         });
         // Then start a auth to prove it is working
         const newContainer = new ReactNativeContainer({
-          name: 'appInitiatedSSOToWeb',
+          name: 'preAuthenticatedURL',
         });
         await newContainer.configure({
           endpoint: endpoint,
@@ -608,7 +607,7 @@ const HomeScreen: React.FC = () => {
         const userInfo = await newContainer.fetchUserInfo();
         showUser(userInfo);
       } else {
-        // This willbe redirected to appInitiatedSSOToWebRedirectURI and never close,
+        // This willbe redirected to preAuthenticatedURLRedirectURI and never close,
         // so we do not await
         uiImpl
           .openAuthorizationURL({
@@ -624,7 +623,7 @@ const HomeScreen: React.FC = () => {
     } finally {
       setLoading(false);
     }
-  }, [authgear, appInitiatedSSOToWebRedirectURI, appInitiatedSSOToWebClientID]);
+  }, [authgear, preAuthenticatedURLRedirectURI, preAuthenticatedURLClientID]);
 
   const openSettings = useCallback(() => {
     authgear
@@ -769,22 +768,20 @@ const HomeScreen: React.FC = () => {
         </View>
         <View style={styles.input}>
           <Text style={styles.inputLabel}>
-            Is App Initiated SSO To Web Enabled
+            Is Pre Authenticated URL Enabled
           </Text>
           <Switch
             style={styles.checkbox}
             value={preAuthenticatedURLEnabled}
-            onValueChange={setIsAppInitiatedSSOToWebEnabled}
+            onValueChange={setIsPreAuthenticatedURLEnabled}
           />
         </View>
         <View style={styles.input}>
-          <Text style={styles.inputLabel}>
-            App Initiated SSO To Web Client ID
-          </Text>
+          <Text style={styles.inputLabel}>Pre Authenticated URL Client ID</Text>
           <TextInput
             style={styles.inputField}
-            value={appInitiatedSSOToWebClientID}
-            onChangeText={setAppInitiatedSSOToWebClientID}
+            value={preAuthenticatedURLClientID}
+            onChangeText={setPreAuthenticatedURLClientID}
             autoCapitalize="none"
             autoCorrect={false}
             placeholder="Enter Client ID"
@@ -792,12 +789,12 @@ const HomeScreen: React.FC = () => {
         </View>
         <View style={styles.input}>
           <Text style={styles.inputLabel}>
-            App Initiated SSO To Web Redirect URI
+            Pre Authenticated URL Redirect URI
           </Text>
           <TextInput
             style={styles.inputField}
-            value={appInitiatedSSOToWebRedirectURI}
-            onChangeText={setAppInitiatedSSOToWebRedirectURI}
+            value={preAuthenticatedURLRedirectURI}
+            onChangeText={setPreAuthenticatedURLRedirectURI}
             autoCapitalize="none"
             autoCorrect={false}
             placeholder="Enter Redirect URI"
@@ -878,8 +875,8 @@ const HomeScreen: React.FC = () => {
         </View>
         <View style={styles.button}>
           <Button
-            title="App Initiated SSO To Web"
-            onPress={startAppInitiatedSSOToWeb}
+            title="Pre Authenticated URL"
+            onPress={startPreAuthenticatedURL}
             disabled={
               !initialized ||
               loading ||

--- a/example/reactnative/src/screens/MainScreen.tsx
+++ b/example/reactnative/src/screens/MainScreen.tsx
@@ -579,8 +579,8 @@ const HomeScreen: React.FC = () => {
     }
     try {
       const url = await authgear.makePreAuthenticatedURL({
-        clientID: targetClientID,
-        redirectURI: targetRedirectURI,
+        webApplicationClientID: targetClientID,
+        webApplicationURI: targetRedirectURI,
       });
       const uiImpl = new WebKitWebViewUIImplementation();
       if (!shouldUseAnotherBrowser) {
@@ -623,7 +623,14 @@ const HomeScreen: React.FC = () => {
     } finally {
       setLoading(false);
     }
-  }, [authgear, preAuthenticatedURLRedirectURI, preAuthenticatedURLClientID]);
+  }, [
+    preAuthenticatedURLRedirectURI,
+    clientID,
+    preAuthenticatedURLClientID,
+    endpoint,
+    showUser,
+    showError,
+  ]);
 
   const openSettings = useCallback(() => {
     authgear

--- a/example/reactnative/src/screens/MainScreen.tsx
+++ b/example/reactnative/src/screens/MainScreen.tsx
@@ -584,7 +584,7 @@ const HomeScreen: React.FC = () => {
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [authgear, appInitiatedSSOToWebClientID]);
 
   const openSettings = useCallback(() => {
     authgear

--- a/example/reactnative/src/screens/MainScreen.tsx
+++ b/example/reactnative/src/screens/MainScreen.tsx
@@ -161,7 +161,7 @@ const HomeScreen: React.FC = () => {
   const [useWebKitWebView, setUseWebKitWebView] = useState(false);
   const [biometricEnabled, setBiometricEnabled] = useState<boolean>(false);
 
-  const [isAppInitiatedSSOToWebEnabled, setIsAppInitiatedSSOToWebEnabled] =
+  const [preAuthenticatedURLEnabled, setIsAppInitiatedSSOToWebEnabled] =
     useState(false);
   const [appInitiatedSSOToWebClientID, setAppInitiatedSSOToWebClientID] =
     useState('');
@@ -374,7 +374,7 @@ const HomeScreen: React.FC = () => {
             })
           : undefined,
         isSSOEnabled,
-        isAppInitiatedSSOToWebEnabled,
+        preAuthenticatedURLEnabled,
       })
       .then(() => {
         postConfigure();
@@ -391,7 +391,7 @@ const HomeScreen: React.FC = () => {
     endpoint,
     useTransientTokenStorage,
     isSSOEnabled,
-    isAppInitiatedSSOToWebEnabled,
+    preAuthenticatedURLEnabled,
     useWebKitWebView,
     postConfigure,
     showError,
@@ -773,7 +773,7 @@ const HomeScreen: React.FC = () => {
           </Text>
           <Switch
             style={styles.checkbox}
-            value={isAppInitiatedSSOToWebEnabled}
+            value={preAuthenticatedURLEnabled}
             onValueChange={setIsAppInitiatedSSOToWebEnabled}
           />
         </View>
@@ -884,7 +884,7 @@ const HomeScreen: React.FC = () => {
               !initialized ||
               loading ||
               !loggedIn ||
-              !isAppInitiatedSSOToWebEnabled
+              !preAuthenticatedURLEnabled
             }
           />
         </View>

--- a/packages/authgear-capacitor/src/index.ts
+++ b/packages/authgear-capacitor/src/index.ts
@@ -41,7 +41,7 @@ import {
   type SettingOptions,
   type BiometricOptions,
   type SettingsActionOptions,
-  AppInitiatedSSOToWebOptions,
+  type AppInitiatedSSOToWebOptions,
 } from "./types";
 import { BiometricPrivateKeyNotFoundError } from "./error";
 

--- a/packages/authgear-capacitor/src/index.ts
+++ b/packages/authgear-capacitor/src/index.ts
@@ -671,29 +671,11 @@ export class CapacitorContainer {
   /**
    * @internal
    */
-  getScopes(): string[] {
-    const scopes = [
-      "openid",
-      "offline_access",
-      "https://authgear.com/scopes/full-access",
-    ];
-    if (this.isAppInitiatedSSOToWebEnabled) {
-      scopes.push(
-        "device_sso",
-        "https://authgear.com/scopes/app-initiated-sso-to-web"
-      );
-    }
-    return scopes;
-  }
-
-  /**
-   * @internal
-   */
   async authorizeEndpoint(options: AuthenticateOptions): Promise<string> {
     return this.baseContainer.authorizeEndpoint({
       ...options,
       responseType: "code",
-      scope: this.getScopes(),
+      scope: this.baseContainer.getScopes(),
     });
   }
 

--- a/packages/authgear-capacitor/src/index.ts
+++ b/packages/authgear-capacitor/src/index.ts
@@ -95,6 +95,12 @@ export interface ConfigureOptions {
    */
   isSSOEnabled?: boolean;
 
+  /**
+   * When isAppInitiatedSSOToWebEnabled is true, native apps can share session with a web browser.
+   * @defaultValue false
+   */
+  isAppInitiatedSSOToWebEnabled?: boolean;
+
   /*
    * The UIImplementation.
    */
@@ -192,6 +198,22 @@ export class CapacitorContainer {
 
   public set isSSOEnabled(isSSOEnabled: boolean) {
     this.baseContainer.isSSOEnabled = isSSOEnabled;
+  }
+
+  /**
+   * Is App Initiated SSO To Web enabled
+   *
+   * @public
+   */
+  public get isAppInitiatedSSOToWebEnabled(): boolean {
+    return this.baseContainer.isAppInitiatedSSOToWebEnabled;
+  }
+
+  public set isAppInitiatedSSOToWebEnabled(
+    isAppInitiatedSSOToWebEnabled: boolean
+  ) {
+    this.baseContainer.isAppInitiatedSSOToWebEnabled =
+      isAppInitiatedSSOToWebEnabled;
   }
 
   /**
@@ -300,6 +322,8 @@ export class CapacitorContainer {
    */
   async configure(options: ConfigureOptions): Promise<void> {
     this.isSSOEnabled = options.isSSOEnabled ?? false;
+    this.isAppInitiatedSSOToWebEnabled =
+      options.isAppInitiatedSSOToWebEnabled ?? false;
     if (options.tokenStorage != null) {
       this.tokenStorage = options.tokenStorage;
     } else {
@@ -646,15 +670,29 @@ export class CapacitorContainer {
   /**
    * @internal
    */
+  getScopes(): string[] {
+    const scopes = [
+      "openid",
+      "offline_access",
+      "https://authgear.com/scopes/full-access",
+    ];
+    if (this.isAppInitiatedSSOToWebEnabled) {
+      scopes.push(
+        "device_sso",
+        "https://authgear.com/scopes/app-initiated-sso-to-web"
+      );
+    }
+    return scopes;
+  }
+
+  /**
+   * @internal
+   */
   async authorizeEndpoint(options: AuthenticateOptions): Promise<string> {
     return this.baseContainer.authorizeEndpoint({
       ...options,
       responseType: "code",
-      scope: [
-        "openid",
-        "offline_access",
-        "https://authgear.com/scopes/full-access",
-      ],
+      scope: this.getScopes(),
     });
   }
 

--- a/packages/authgear-capacitor/src/index.ts
+++ b/packages/authgear-capacitor/src/index.ts
@@ -486,7 +486,7 @@ export class CapacitorContainer {
       maxAge,
       idTokenHint: idToken,
       responseType: "code",
-      scope: ["openid", "https://authgear.com/scopes/full-access"],
+      scope: this.baseContainer.getReauthenticateScopes(),
     });
 
     const redirectURL = await this.uiImplementation.openAuthorizationURL({
@@ -610,7 +610,7 @@ export class CapacitorContainer {
       loginHint,
       idTokenHint: idToken,
       responseType: "urn:authgear:params:oauth:response-type:settings-action",
-      scope: ["openid", "https://authgear.com/scopes/full-access"],
+      scope: this.baseContainer.getSettingsActionScopes(),
       xSettingsAction: action,
     });
     const redirectURL = await this.uiImplementation.openAuthorizationURL({
@@ -675,7 +675,9 @@ export class CapacitorContainer {
     return this.baseContainer.authorizeEndpoint({
       ...options,
       responseType: "code",
-      scope: this.baseContainer.getScopes(),
+      scope: this.baseContainer.getAuthenticateScopes({
+        requestOfflineAccess: true,
+      }),
     });
   }
 
@@ -775,7 +777,9 @@ export class CapacitorContainer {
           grant_type: "urn:authgear:params:oauth:grant-type:biometric-request",
           client_id: clientID,
           jwt,
-          scope: this.baseContainer.getScopes(),
+          scope: this.baseContainer.getAuthenticateScopes({
+            requestOfflineAccess: true,
+          }),
         });
 
       const userInfo = await this.baseContainer.apiClient._oidcUserInfoRequest(

--- a/packages/authgear-capacitor/src/index.ts
+++ b/packages/authgear-capacitor/src/index.ts
@@ -820,10 +820,10 @@ export class CapacitorContainer {
    *
    * @public
    */
-  async makeAppInitiatedSSOToWebURL(
+  async makePreAuthenticatedURL(
     options: AppInitiatedSSOToWebOptions
   ): Promise<string> {
-    return this.baseContainer._makeAppInitiatedSSOToWebURL({ ...options });
+    return this.baseContainer._makePreAuthenticatedURL({ ...options });
   }
 }
 

--- a/packages/authgear-capacitor/src/index.ts
+++ b/packages/authgear-capacitor/src/index.ts
@@ -102,10 +102,10 @@ export interface ConfigureOptions {
   isSSOEnabled?: boolean;
 
   /**
-   * When isAppInitiatedSSOToWebEnabled is true, native apps can share session with a web browser.
+   * When preAuthenticatedURLEnabled is true, native apps can share session with a web browser.
    * @defaultValue false
    */
-  isAppInitiatedSSOToWebEnabled?: boolean;
+  preAuthenticatedURLEnabled?: boolean;
 
   /*
    * The UIImplementation.
@@ -216,15 +216,12 @@ export class CapacitorContainer {
    *
    * @public
    */
-  public get isAppInitiatedSSOToWebEnabled(): boolean {
-    return this.baseContainer.isAppInitiatedSSOToWebEnabled;
+  public get preAuthenticatedURLEnabled(): boolean {
+    return this.baseContainer.preAuthenticatedURLEnabled;
   }
 
-  public set isAppInitiatedSSOToWebEnabled(
-    isAppInitiatedSSOToWebEnabled: boolean
-  ) {
-    this.baseContainer.isAppInitiatedSSOToWebEnabled =
-      isAppInitiatedSSOToWebEnabled;
+  public set preAuthenticatedURLEnabled(preAuthenticatedURLEnabled: boolean) {
+    this.baseContainer.preAuthenticatedURLEnabled = preAuthenticatedURLEnabled;
   }
 
   /**
@@ -334,8 +331,8 @@ export class CapacitorContainer {
    */
   async configure(options: ConfigureOptions): Promise<void> {
     this.isSSOEnabled = options.isSSOEnabled ?? false;
-    this.isAppInitiatedSSOToWebEnabled =
-      options.isAppInitiatedSSOToWebEnabled ?? false;
+    this.preAuthenticatedURLEnabled =
+      options.preAuthenticatedURLEnabled ?? false;
     if (options.tokenStorage != null) {
       this.tokenStorage = options.tokenStorage;
     } else {
@@ -819,7 +816,7 @@ export class CapacitorContainer {
   /**
    * Share the current authenticated session to a web browser.
    *
-   * `isAppInitiatedSSOToWebEnabled` must be set to true to use this method.
+   * `preAuthenticatedURLEnabled` must be set to true to use this method.
    *
    * @public
    */

--- a/packages/authgear-capacitor/src/index.ts
+++ b/packages/authgear-capacitor/src/index.ts
@@ -16,8 +16,13 @@ import {
   _ContainerStorage,
   _base64URLEncode,
   _encodeUTF8,
+  SharedStorage,
 } from "@authgear/core";
-import { PersistentContainerStorage, PersistentTokenStorage } from "./storage";
+import {
+  PersistentContainerStorage,
+  PersistentSharedStorage,
+  PersistentTokenStorage,
+} from "./storage";
 import { generateCodeVerifier, computeCodeChallenge } from "./pkce";
 import {
   generateUUID,
@@ -153,6 +158,11 @@ export class CapacitorContainer {
   /**
    * @internal
    */
+  sharedStorage: SharedStorage;
+
+  /**
+   * @internal
+   */
   uiImplementation: UIImplementation;
 
   /**
@@ -249,6 +259,7 @@ export class CapacitorContainer {
 
     this.storage = new PersistentContainerStorage();
     this.tokenStorage = new PersistentTokenStorage();
+    this.sharedStorage = new PersistentSharedStorage();
     this.uiImplementation = new DeviceBrowserUIImplementation();
   }
 

--- a/packages/authgear-capacitor/src/index.ts
+++ b/packages/authgear-capacitor/src/index.ts
@@ -16,11 +16,11 @@ import {
   _ContainerStorage,
   _base64URLEncode,
   _encodeUTF8,
-  SharedStorage,
+  InterAppSharedStorage,
 } from "@authgear/core";
 import {
   PersistentContainerStorage,
-  PersistentSharedStorage,
+  PersistentInterAppSharedStorage,
   PersistentTokenStorage,
 } from "./storage";
 import { generateCodeVerifier, computeCodeChallenge } from "./pkce";
@@ -158,7 +158,7 @@ export class CapacitorContainer {
   /**
    * @internal
    */
-  sharedStorage: SharedStorage;
+  sharedStorage: InterAppSharedStorage;
 
   /**
    * @internal
@@ -259,7 +259,7 @@ export class CapacitorContainer {
 
     this.storage = new PersistentContainerStorage();
     this.tokenStorage = new PersistentTokenStorage();
-    this.sharedStorage = new PersistentSharedStorage();
+    this.sharedStorage = new PersistentInterAppSharedStorage();
     this.uiImplementation = new DeviceBrowserUIImplementation();
   }
 

--- a/packages/authgear-capacitor/src/index.ts
+++ b/packages/authgear-capacitor/src/index.ts
@@ -870,9 +870,20 @@ export class CapacitorContainer {
       await this.tokenStorage.setDeviceSecret(this.name, newDeviceSecret);
     }
     if (newIDToken != null) {
+      idToken = newIDToken;
       await this.tokenStorage.setIDToken(this.name, newIDToken);
     }
-    // TODO(tung): Exchange for cookies
+    const url = await this.baseContainer.authorizeEndpoint({
+      responseType:
+        "urn:authgear:params:oauth:response-type:app_initiated_sso_to_web token",
+      responseMode: "cookie",
+      redirectURI: options.redirectURI,
+      clientID: options.clientID,
+      xAppInitiatedSSOToWebToken: appInitiatedSSOToWebToken,
+      idTokenHint: idToken,
+      prompt: PromptOption.None,
+    });
+    return url;
   }
 }
 

--- a/packages/authgear-capacitor/src/index.ts
+++ b/packages/authgear-capacitor/src/index.ts
@@ -828,62 +828,7 @@ export class CapacitorContainer {
   async makeAppInitiatedSSOToWebURL(
     options: AppInitiatedSSOToWebOptions
   ): Promise<string> {
-    const clientID = options.clientID;
-    if (!this.isAppInitiatedSSOToWebEnabled) {
-      throw new AuthgearError(
-        "makeAppInitiatedSSOToWebURL requires isAppInitiatedSSOToWebEnabled to be true"
-      );
-    }
-    if (this.sessionState !== SessionState.Authenticated) {
-      throw new AuthgearError(
-        "makeAppInitiatedSSOToWebURL requires authenticated user"
-      );
-    }
-    let idToken = await this.tokenStorage.getIDToken(this.name);
-    if (!idToken) {
-      throw new AuthgearError("id_token not found");
-    }
-    const deviceSecret = await this.tokenStorage.getDeviceSecret(this.name);
-    if (!deviceSecret) {
-      throw new AuthgearError("device_secret not found");
-    }
-    const tokenExchangeResult =
-      await this.baseContainer.apiClient._oidcTokenRequest({
-        client_id: clientID,
-        grant_type: "urn:ietf:params:oauth:grant-type:token-exchange",
-        requested_token_type:
-          "urn:authgear:params:oauth:token-type:app-initiated-sso-to-web-token",
-        audience: this.baseContainer.apiClient.endpoint,
-        subject_token_type: "urn:ietf:params:oauth:token-type:id_token",
-        subject_token: idToken,
-        actor_token_type: "urn:x-oath:params:oauth:token-type:device-secret",
-        actor_token: deviceSecret,
-      });
-    // Here access_token is app-initiated-sso-to-web-token
-    const appInitiatedSSOToWebToken = tokenExchangeResult.access_token;
-    const newDeviceSecret = tokenExchangeResult.device_secret;
-    const newIDToken = tokenExchangeResult.id_token;
-    if (appInitiatedSSOToWebToken == null) {
-      throw new AuthgearError("unexpected: access_token is not returned");
-    }
-    if (newDeviceSecret != null) {
-      await this.tokenStorage.setDeviceSecret(this.name, newDeviceSecret);
-    }
-    if (newIDToken != null) {
-      idToken = newIDToken;
-      await this.tokenStorage.setIDToken(this.name, newIDToken);
-    }
-    const url = await this.baseContainer.authorizeEndpoint({
-      responseType:
-        "urn:authgear:params:oauth:response-type:app_initiated_sso_to_web token",
-      responseMode: "cookie",
-      redirectURI: options.redirectURI,
-      clientID: options.clientID,
-      xAppInitiatedSSOToWebToken: appInitiatedSSOToWebToken,
-      idTokenHint: idToken,
-      prompt: PromptOption.None,
-    });
-    return url;
+    return this.baseContainer._makeAppInitiatedSSOToWebURL({ ...options });
   }
 }
 

--- a/packages/authgear-capacitor/src/index.ts
+++ b/packages/authgear-capacitor/src/index.ts
@@ -41,6 +41,7 @@ import {
   type SettingOptions,
   type BiometricOptions,
   type SettingsActionOptions,
+  AppInitiatedSSOToWebOptions,
 } from "./types";
 import { BiometricPrivateKeyNotFoundError } from "./error";
 
@@ -815,6 +816,63 @@ export class CapacitorContainer {
       }
       throw e;
     }
+  }
+
+  /**
+   * Share the current authenticated session to a web browser.
+   *
+   * `isAppInitiatedSSOToWebEnabled` must be set to true to use this method.
+   *
+   * @public
+   */
+  async makeAppInitiatedSSOToWebURL(
+    options: AppInitiatedSSOToWebOptions
+  ): Promise<string> {
+    const clientID = options.clientID;
+    if (!this.isAppInitiatedSSOToWebEnabled) {
+      throw new AuthgearError(
+        "makeAppInitiatedSSOToWebURL requires isAppInitiatedSSOToWebEnabled to be true"
+      );
+    }
+    if (this.sessionState !== SessionState.Authenticated) {
+      throw new AuthgearError(
+        "makeAppInitiatedSSOToWebURL requires authenticated user"
+      );
+    }
+    let idToken = await this.tokenStorage.getIDToken(this.name);
+    if (!idToken) {
+      throw new AuthgearError("id_token not found");
+    }
+    const deviceSecret = await this.tokenStorage.getDeviceSecret(this.name);
+    if (!deviceSecret) {
+      throw new AuthgearError("device_secret not found");
+    }
+    const tokenExchangeResult =
+      await this.baseContainer.apiClient._oidcTokenRequest({
+        client_id: clientID,
+        grant_type: "urn:ietf:params:oauth:grant-type:token-exchange",
+        requested_token_type:
+          "urn:authgear:params:oauth:token-type:app-initiated-sso-to-web-token",
+        audience: this.baseContainer.apiClient.endpoint,
+        subject_token_type: "urn:ietf:params:oauth:token-type:id_token",
+        subject_token: idToken,
+        actor_token_type: "urn:x-oath:params:oauth:token-type:device-secret",
+        actor_token: deviceSecret,
+      });
+    // Here access_token is app-initiated-sso-to-web-token
+    const appInitiatedSSOToWebToken = tokenExchangeResult.access_token;
+    const newDeviceSecret = tokenExchangeResult.device_secret;
+    const newIDToken = tokenExchangeResult.id_token;
+    if (appInitiatedSSOToWebToken == null) {
+      throw new AuthgearError("unexpected: access_token is not returned");
+    }
+    if (newDeviceSecret != null) {
+      await this.tokenStorage.setDeviceSecret(this.name, newDeviceSecret);
+    }
+    if (newIDToken != null) {
+      await this.tokenStorage.setIDToken(this.name, newIDToken);
+    }
+    // TODO(tung): Exchange for cookies
   }
 }
 

--- a/packages/authgear-capacitor/src/index.ts
+++ b/packages/authgear-capacitor/src/index.ts
@@ -46,7 +46,7 @@ import {
   type SettingOptions,
   type BiometricOptions,
   type SettingsActionOptions,
-  type AppInitiatedSSOToWebOptions,
+  type PreAuthenticatedURLOptions,
 } from "./types";
 import { BiometricPrivateKeyNotFoundError } from "./error";
 
@@ -212,7 +212,7 @@ export class CapacitorContainer {
   }
 
   /**
-   * Is App Initiated SSO To Web enabled
+   * Is Pre Authenticated URL enabled
    *
    * @public
    */
@@ -821,7 +821,7 @@ export class CapacitorContainer {
    * @public
    */
   async makePreAuthenticatedURL(
-    options: AppInitiatedSSOToWebOptions
+    options: PreAuthenticatedURLOptions
   ): Promise<string> {
     return this.baseContainer._makePreAuthenticatedURL({ ...options });
   }

--- a/packages/authgear-capacitor/src/index.ts
+++ b/packages/authgear-capacitor/src/index.ts
@@ -775,6 +775,7 @@ export class CapacitorContainer {
           grant_type: "urn:authgear:params:oauth:grant-type:biometric-request",
           client_id: clientID,
           jwt,
+          scope: this.baseContainer.getScopes(),
         });
 
       const userInfo = await this.baseContainer.apiClient._oidcUserInfoRequest(

--- a/packages/authgear-capacitor/src/storage.ts
+++ b/packages/authgear-capacitor/src/storage.ts
@@ -4,6 +4,7 @@ import {
   _ContainerStorage,
   _KeyMaker,
   _SafeStorageDriver,
+  SharedStorage,
 } from "@authgear/core";
 import { storageGetItem, storageSetItem, storageDeleteItem } from "./plugin";
 
@@ -54,6 +55,19 @@ export class PersistentTokenStorage implements TokenStorage {
   }
   async delRefreshToken(namespace: string): Promise<void> {
     await this.storageDriver.del(this.keyMaker.keyRefreshToken(namespace));
+  }
+}
+
+/**
+ * @internal
+ */
+export class PersistentSharedStorage implements SharedStorage {
+  private keyMaker: _KeyMaker;
+  private storageDriver: _StorageDriver;
+
+  constructor() {
+    this.keyMaker = new _KeyMaker();
+    this.storageDriver = new _SafeStorageDriver(new _PlatformStorageDriver());
   }
 
   async setIDToken(namespace: string, idToken: string): Promise<void> {

--- a/packages/authgear-capacitor/src/storage.ts
+++ b/packages/authgear-capacitor/src/storage.ts
@@ -4,7 +4,7 @@ import {
   _ContainerStorage,
   _KeyMaker,
   _SafeStorageDriver,
-  SharedStorage,
+  InterAppSharedStorage,
 } from "@authgear/core";
 import { storageGetItem, storageSetItem, storageDeleteItem } from "./plugin";
 
@@ -61,7 +61,7 @@ export class PersistentTokenStorage implements TokenStorage {
 /**
  * @internal
  */
-export class PersistentSharedStorage implements SharedStorage {
+export class PersistentInterAppSharedStorage implements InterAppSharedStorage {
   private keyMaker: _KeyMaker;
   private storageDriver: _StorageDriver;
 

--- a/packages/authgear-capacitor/src/storage.ts
+++ b/packages/authgear-capacitor/src/storage.ts
@@ -49,13 +49,37 @@ export class PersistentTokenStorage implements TokenStorage {
       refreshToken
     );
   }
-
   async getRefreshToken(namespace: string): Promise<string | null> {
     return this.storageDriver.get(this.keyMaker.keyRefreshToken(namespace));
   }
-
   async delRefreshToken(namespace: string): Promise<void> {
     await this.storageDriver.del(this.keyMaker.keyRefreshToken(namespace));
+  }
+
+  async setIDToken(namespace: string, idToken: string): Promise<void> {
+    return this.storageDriver.set(this.keyMaker.keyIDToken(namespace), idToken);
+  }
+  async getIDToken(namespace: string): Promise<string | null> {
+    return this.storageDriver.get(this.keyMaker.keyIDToken(namespace));
+  }
+  async delIDToken(namespace: string): Promise<void> {
+    return this.storageDriver.del(this.keyMaker.keyIDToken(namespace));
+  }
+
+  async setDeviceSecret(
+    namespace: string,
+    deviceSecret: string
+  ): Promise<void> {
+    return this.storageDriver.set(
+      this.keyMaker.keyDeviceSecret(namespace),
+      deviceSecret
+    );
+  }
+  async getDeviceSecret(namespace: string): Promise<string | null> {
+    return this.storageDriver.get(this.keyMaker.keyDeviceSecret(namespace));
+  }
+  async delDeviceSecret(namespace: string): Promise<void> {
+    return this.storageDriver.del(this.keyMaker.keyDeviceSecret(namespace));
   }
 }
 

--- a/packages/authgear-capacitor/src/types.ts
+++ b/packages/authgear-capacitor/src/types.ts
@@ -365,3 +365,23 @@ export interface BiometricPrivateKeyOptions extends BiometricOptions {
     device_info: unknown;
   };
 }
+
+/**
+ * AppInitiatedSSOToWebOptions is options for app-initiated-sso-to-web.
+ *
+ * @public
+ */
+export interface AppInitiatedSSOToWebOptions {
+  /**
+   * The client ID of the new authenticated session in web.
+   */
+  clientID: string;
+  /**
+   * The URI the browser should go to after successfully obtained a authenticated session.
+   */
+  redirectURI: string;
+  /**
+   * Any string that will be passed to redirectURI by the `state` query parameter.
+   */
+  state?: string;
+}

--- a/packages/authgear-capacitor/src/types.ts
+++ b/packages/authgear-capacitor/src/types.ts
@@ -373,15 +373,15 @@ export interface BiometricPrivateKeyOptions extends BiometricOptions {
  */
 export interface PreAuthenticatedURLOptions {
   /**
-   * The client ID of the new authenticated session in web.
+   * The client ID of the web application.
    */
-  clientID: string;
+  webApplicationClientID: string;
   /**
    * The URI the browser should go to after successfully obtained a authenticated session.
    */
-  redirectURI: string;
+  webApplicationURI: string;
   /**
-   * Any string that will be passed to redirectURI by the `state` query parameter.
+   * Any string that will be passed to webApplicationURI by the `state` query parameter.
    */
   state?: string;
 }

--- a/packages/authgear-capacitor/src/types.ts
+++ b/packages/authgear-capacitor/src/types.ts
@@ -367,11 +367,11 @@ export interface BiometricPrivateKeyOptions extends BiometricOptions {
 }
 
 /**
- * AppInitiatedSSOToWebOptions is options for app-initiated-sso-to-web.
+ * PreAuthenticatedURLOptions is options for pre-authenticated-url.
  *
  * @public
  */
-export interface AppInitiatedSSOToWebOptions {
+export interface PreAuthenticatedURLOptions {
   /**
    * The client ID of the new authenticated session in web.
    */

--- a/packages/authgear-core/src/client.ts
+++ b/packages/authgear-core/src/client.ts
@@ -384,6 +384,11 @@ export abstract class _BaseAPIClient {
     });
   }
 
+  async getEndpointOrigin(): Promise<string> {
+    const config = await this._fetchOIDCConfiguration();
+    return new URL(config.authorization_endpoint).origin;
+  }
+
   async appSessionToken(
     refreshToken: string
   ): Promise<_AppSessionTokenResponse> {

--- a/packages/authgear-core/src/client.ts
+++ b/packages/authgear-core/src/client.ts
@@ -295,9 +295,6 @@ export abstract class _BaseAPIClient {
     if (req.scope != null) {
       query.append("scope", req.scope.join(" "));
     }
-    // if (req.requested_token_type) {
-    //   query.append("requested_token_type", req.requested_token_type);
-    // }
     const headers: Record<string, string> = {
       "content-type": "application/x-www-form-urlencoded",
     };

--- a/packages/authgear-core/src/client.ts
+++ b/packages/authgear-core/src/client.ts
@@ -267,24 +267,37 @@ export abstract class _BaseAPIClient {
     const query = new URLSearchParams();
     query.append("grant_type", req.grant_type);
     query.append("client_id", req.client_id);
-    if (req.code) {
-      query.append("code", req.code);
+    const appendKeyAsString = (key: keyof _OIDCTokenRequest) => {
+      const value = req[key];
+      if (value) {
+        if (typeof value !== "string") {
+          throw new Error("value is not a string");
+        }
+        query.append(key, value);
+      }
+    };
+    for (const k of [
+      "code",
+      "redirect_uri",
+      "code_verifier",
+      "refresh_token",
+      "jwt",
+      "x_device_info",
+      "requested_token_type",
+      "subject_token",
+      "subject_token_type",
+      "actor_token",
+      "actor_token_type",
+      "audience",
+    ] as (keyof _OIDCTokenRequest)[]) {
+      appendKeyAsString(k);
     }
-    if (req.redirect_uri) {
-      query.append("redirect_uri", req.redirect_uri);
+    if (req.scope != null) {
+      query.append("scope", req.scope.join(" "));
     }
-    if (req.code_verifier) {
-      query.append("code_verifier", req.code_verifier);
-    }
-    if (req.refresh_token) {
-      query.append("refresh_token", req.refresh_token);
-    }
-    if (req.jwt) {
-      query.append("jwt", req.jwt);
-    }
-    if (req.x_device_info) {
-      query.append("x_device_info", req.x_device_info);
-    }
+    // if (req.requested_token_type) {
+    //   query.append("requested_token_type", req.requested_token_type);
+    // }
     const headers: Record<string, string> = {
       "content-type": "application/x-www-form-urlencoded",
     };

--- a/packages/authgear-core/src/container.ts
+++ b/packages/authgear-core/src/container.ts
@@ -694,12 +694,13 @@ export class _BaseContainer<T extends _BaseAPIClient> {
   }): Promise<_OIDCTokenResponse> {
     const { clientID, idToken, deviceSecret } = options;
     try {
+      const audience = await this.apiClient.getEndpointOrigin();
       const tokenExchangeResult = await this.apiClient._oidcTokenRequest({
         client_id: clientID,
         grant_type: "urn:ietf:params:oauth:grant-type:token-exchange",
         requested_token_type:
           "urn:authgear:params:oauth:token-type:app-initiated-sso-to-web-token",
-        audience: this.apiClient.endpoint,
+        audience: audience,
         subject_token_type: "urn:ietf:params:oauth:token-type:id_token",
         subject_token: idToken,
         actor_token_type: "urn:x-oath:params:oauth:token-type:device-secret",

--- a/packages/authgear-core/src/container.ts
+++ b/packages/authgear-core/src/container.ts
@@ -123,7 +123,7 @@ export class _BaseContainer<T extends _BaseAPIClient> {
 
   isSSOEnabled: boolean;
 
-  isAppInitiatedSSOToWebEnabled: boolean;
+  preAuthenticatedURLEnabled: boolean;
 
   sessionState: SessionState;
 
@@ -147,7 +147,7 @@ export class _BaseContainer<T extends _BaseAPIClient> {
     this.name = options.name ?? "default";
     this.apiClient = apiClient;
     this.isSSOEnabled = false;
-    this.isAppInitiatedSSOToWebEnabled = false;
+    this.preAuthenticatedURLEnabled = false;
     this.sessionState = SessionState.Unknown;
     this._delegate = _delegate;
   }
@@ -178,7 +178,7 @@ export class _BaseContainer<T extends _BaseAPIClient> {
     if (requestOfflineAccess) {
       scopes.push("offline_access");
     }
-    if (this.isAppInitiatedSSOToWebEnabled) {
+    if (this.preAuthenticatedURLEnabled) {
       scopes.push(
         "device_sso",
         "https://authgear.com/scopes/app-initiated-sso-to-web"
@@ -743,9 +743,9 @@ export class _BaseContainer<T extends _BaseAPIClient> {
     options: _AppInitiatedSSOToWebOptions
   ): Promise<string> {
     const clientID = options.clientID;
-    if (!this.isAppInitiatedSSOToWebEnabled) {
+    if (!this.preAuthenticatedURLEnabled) {
       throw new AuthgearError(
-        "makeAppInitiatedSSOToWebURL requires isAppInitiatedSSOToWebEnabled to be true"
+        "makeAppInitiatedSSOToWebURL requires preAuthenticatedURLEnabled to be true"
       );
     }
     if (this.sessionState !== SessionState.Authenticated) {

--- a/packages/authgear-core/src/container.ts
+++ b/packages/authgear-core/src/container.ts
@@ -181,7 +181,7 @@ export class _BaseContainer<T extends _BaseAPIClient> {
     if (this.preAuthenticatedURLEnabled) {
       scopes.push(
         "device_sso",
-        "https://authgear.com/scopes/app-initiated-sso-to-web"
+        "https://authgear.com/scopes/pre-authenticated-url"
       );
     }
     return scopes;

--- a/packages/authgear-core/src/container.ts
+++ b/packages/authgear-core/src/container.ts
@@ -493,10 +493,10 @@ export class _BaseContainer<T extends _BaseAPIClient> {
     if (options.xSettingsAction != null) {
       query.append("x_settings_action", options.xSettingsAction);
     }
-    if (options.xAppInitiatedSSOToWebToken != null) {
+    if (options.xPreAuthenticatedURLToken != null) {
       query.append(
-        "x_app_initiated_sso_to_web_token",
-        options.xAppInitiatedSSOToWebToken
+        "x_pre_authenticated_url_token",
+        options.xPreAuthenticatedURLToken
       );
     }
     if (!this.isSSOEnabled) {
@@ -793,7 +793,7 @@ export class _BaseContainer<T extends _BaseAPIClient> {
       responseMode: "cookie",
       redirectURI: options.redirectURI,
       clientID: options.clientID,
-      xAppInitiatedSSOToWebToken: appInitiatedSSOToWebToken,
+      xPreAuthenticatedURLToken: appInitiatedSSOToWebToken,
       idTokenHint: idToken,
       prompt: PromptOption.None,
       state: options.state,

--- a/packages/authgear-core/src/container.ts
+++ b/packages/authgear-core/src/container.ts
@@ -739,18 +739,18 @@ export class _BaseContainer<T extends _BaseAPIClient> {
     }
   }
 
-  async _makeAppInitiatedSSOToWebURL(
+  async _makePreAuthenticatedURL(
     options: _AppInitiatedSSOToWebOptions
   ): Promise<string> {
     const clientID = options.clientID;
     if (!this.preAuthenticatedURLEnabled) {
       throw new AuthgearError(
-        "makeAppInitiatedSSOToWebURL requires preAuthenticatedURLEnabled to be true"
+        "makePreAuthenticatedURL requires preAuthenticatedURLEnabled to be true"
       );
     }
     if (this.sessionState !== SessionState.Authenticated) {
       throw new AuthgearError(
-        "makeAppInitiatedSSOToWebURL requires authenticated user"
+        "makePreAuthenticatedURL requires authenticated user"
       );
     }
     let idToken = await this._delegate.sharedStorage.getIDToken(this.name);

--- a/packages/authgear-core/src/container.ts
+++ b/packages/authgear-core/src/container.ts
@@ -19,7 +19,13 @@ import {
 } from "./types";
 import { _base64URLDecode } from "./base64";
 import { _decodeUTF8 } from "./utf8";
-import { AuthgearError, NotAllowedError, OAuthError } from "./error";
+import {
+  AuthgearError,
+  AppInitiatedSSOToWebIDTokenNotFoundError,
+  AppInitiatedSSOToWebDeviceSecretNotFoundError,
+  AppInitiatedSSOToWebInsufficientScopeError,
+  OAuthError,
+} from "./error";
 import { _BaseAPIClient } from "./client";
 
 /**
@@ -709,9 +715,7 @@ export class _BaseContainer<T extends _BaseAPIClient> {
       return tokenExchangeResult;
     } catch (e: unknown) {
       if (e instanceof OAuthError && e.error === "insufficient_scope") {
-        throw new NotAllowedError(
-          "Insufficient scope. isAppInitiatedSSOToWebEnabled must be true when the user was authenticated."
-        );
+        throw new AppInitiatedSSOToWebInsufficientScopeError();
       }
       throw e;
     }
@@ -733,17 +737,13 @@ export class _BaseContainer<T extends _BaseAPIClient> {
     }
     let idToken = await this._delegate.tokenStorage.getIDToken(this.name);
     if (!idToken) {
-      throw new NotAllowedError(
-        "id_token not found. isAppInitiatedSSOToWebEnabled must be true when the user was authenticated."
-      );
+      throw new AppInitiatedSSOToWebIDTokenNotFoundError();
     }
     const deviceSecret = await this._delegate.tokenStorage.getDeviceSecret(
       this.name
     );
     if (!deviceSecret) {
-      throw new NotAllowedError(
-        "device_secret not found. isAppInitiatedSSOToWebEnabled must be true when the user was authenticated."
-      );
+      throw new AppInitiatedSSOToWebDeviceSecretNotFoundError();
     }
     const tokenExchangeResult =
       await this._exchangeForAppInitiatedSSOToWebToken({

--- a/packages/authgear-core/src/container.ts
+++ b/packages/authgear-core/src/container.ts
@@ -796,6 +796,7 @@ export class _BaseContainer<T extends _BaseAPIClient> {
       xAppInitiatedSSOToWebToken: appInitiatedSSOToWebToken,
       idTokenHint: idToken,
       prompt: PromptOption.None,
+      state: options.state,
     });
     return url;
   }

--- a/packages/authgear-core/src/container.ts
+++ b/packages/authgear-core/src/container.ts
@@ -765,6 +765,7 @@ export class _BaseContainer<T extends _BaseAPIClient> {
     }
     if (newIDToken != null) {
       idToken = newIDToken;
+      this.idToken = newIDToken;
       await this._delegate.tokenStorage.setIDToken(this.name, newIDToken);
     }
     const url = await this.authorizeEndpoint({

--- a/packages/authgear-core/src/container.ts
+++ b/packages/authgear-core/src/container.ts
@@ -742,7 +742,7 @@ export class _BaseContainer<T extends _BaseAPIClient> {
   async _makePreAuthenticatedURL(
     options: _PreAuthenticatedURLOptions
   ): Promise<string> {
-    const clientID = options.clientID;
+    const clientID = options.webApplicationClientID;
     if (!this.preAuthenticatedURLEnabled) {
       throw new AuthgearError(
         "makePreAuthenticatedURL requires preAuthenticatedURLEnabled to be true"
@@ -792,8 +792,8 @@ export class _BaseContainer<T extends _BaseAPIClient> {
       responseType:
         "urn:authgear:params:oauth:response-type:pre-authenticated-url token",
       responseMode: "cookie",
-      redirectURI: options.redirectURI,
-      clientID: options.clientID,
+      redirectURI: options.webApplicationURI,
+      clientID: options.webApplicationClientID,
       xPreAuthenticatedURLToken: preAuthenticatedURLToken,
       idTokenHint: idToken,
       prompt: PromptOption.None,

--- a/packages/authgear-core/src/container.ts
+++ b/packages/authgear-core/src/container.ts
@@ -16,7 +16,7 @@ import {
   UserInfo,
   _AppInitiatedSSOToWebOptions,
   PromptOption,
-  SharedStorage,
+  InterAppSharedStorage,
 } from "./types";
 import { _base64URLDecode } from "./base64";
 import { _decodeUTF8 } from "./utf8";
@@ -50,7 +50,7 @@ const EXPIRE_IN_PERCENTAGE = 0.9;
 export interface _BaseContainerDelegate {
   storage: _ContainerStorage;
   tokenStorage: TokenStorage;
-  sharedStorage: SharedStorage;
+  sharedStorage: InterAppSharedStorage;
   _setupCodeVerifier(): Promise<{
     verifier: string;
     challenge: string;

--- a/packages/authgear-core/src/container.ts
+++ b/packages/authgear-core/src/container.ts
@@ -164,6 +164,21 @@ export class _BaseContainer<T extends _BaseAPIClient> {
     return _getAuthTime(payload);
   }
 
+  getScopes(): string[] {
+    const scopes = [
+      "openid",
+      "offline_access",
+      "https://authgear.com/scopes/full-access",
+    ];
+    if (this.isAppInitiatedSSOToWebEnabled) {
+      scopes.push(
+        "device_sso",
+        "https://authgear.com/scopes/app-initiated-sso-to-web"
+      );
+    }
+    return scopes;
+  }
+
   async _persistTokenResponse(
     response: _OIDCTokenResponse,
     reason: SessionStateChangeReason

--- a/packages/authgear-core/src/container.ts
+++ b/packages/authgear-core/src/container.ts
@@ -170,12 +170,12 @@ export class _BaseContainer<T extends _BaseAPIClient> {
     return _getAuthTime(payload);
   }
 
-  getScopes(): string[] {
-    const scopes = [
-      "openid",
-      "offline_access",
-      "https://authgear.com/scopes/full-access",
-    ];
+  getAuthenticateScopes(options: { requestOfflineAccess: boolean }): string[] {
+    const { requestOfflineAccess } = options;
+    const scopes = ["openid", "https://authgear.com/scopes/full-access"];
+    if (requestOfflineAccess) {
+      scopes.push("offline_access");
+    }
     if (this.isAppInitiatedSSOToWebEnabled) {
       scopes.push(
         "device_sso",
@@ -183,6 +183,22 @@ export class _BaseContainer<T extends _BaseAPIClient> {
       );
     }
     return scopes;
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  getReauthenticateScopes(): string[] {
+    // offline_access is not needed because we don't want a new refresh token to be generated
+    // device_sso and app-initiated-sso-to-web is also not needed,
+    // because no new session should be generated so the scopes are not important.
+    return ["openid", "https://authgear.com/scopes/full-access"];
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  getSettingsActionScopes(): string[] {
+    // offline_access is not needed because we don't want a new refresh token to be generated
+    // device_sso and app-initiated-sso-to-web is also not needed,
+    // because session for settings should not be used to perform SSO.
+    return ["openid", "https://authgear.com/scopes/full-access"];
   }
 
   async _persistTokenResponse(

--- a/packages/authgear-core/src/container.ts
+++ b/packages/authgear-core/src/container.ts
@@ -113,6 +113,8 @@ export class _BaseContainer<T extends _BaseAPIClient> {
 
   isSSOEnabled: boolean;
 
+  isAppInitiatedSSOToWebEnabled: boolean;
+
   sessionState: SessionState;
 
   idToken?: string;
@@ -135,6 +137,7 @@ export class _BaseContainer<T extends _BaseAPIClient> {
     this.name = options.name ?? "default";
     this.apiClient = apiClient;
     this.isSSOEnabled = false;
+    this.isAppInitiatedSSOToWebEnabled = false;
     this.sessionState = SessionState.Unknown;
     this._delegate = _delegate;
   }
@@ -417,7 +420,10 @@ export class _BaseContainer<T extends _BaseAPIClient> {
     }
     query.append("x_sso_enabled", this.isSSOEnabled ? "true" : "false");
     if (options.authenticationFlowGroup != null) {
-      query.append("x_authentication_flow_group", options.authenticationFlowGroup);
+      query.append(
+        "x_authentication_flow_group",
+        options.authenticationFlowGroup
+      );
     }
 
     return `${config.authorization_endpoint}?${query.toString()}`;

--- a/packages/authgear-core/src/container.ts
+++ b/packages/authgear-core/src/container.ts
@@ -352,7 +352,7 @@ export class _BaseContainer<T extends _BaseAPIClient> {
   async authorizeEndpoint(
     options: _OIDCAuthenticationRequest
   ): Promise<string> {
-    const clientID = this.clientID;
+    const clientID = options.clientID ?? this.clientID;
     if (clientID == null) {
       throw new AuthgearError("missing client ID");
     }
@@ -377,7 +377,13 @@ export class _BaseContainer<T extends _BaseAPIClient> {
       query.append("code_challenge", codeVerifier.challenge);
     }
 
-    query.append("scope", options.scope.join(" "));
+    if (options.responseMode != null) {
+      query.append("response_mode", options.responseMode);
+    }
+
+    if (options.scope != null) {
+      query.append("scope", options.scope.join(" "));
+    }
 
     query.append("client_id", clientID);
     query.append("redirect_uri", options.redirectURI);
@@ -423,6 +429,12 @@ export class _BaseContainer<T extends _BaseAPIClient> {
     }
     if (options.xSettingsAction != null) {
       query.append("x_settings_action", options.xSettingsAction);
+    }
+    if (options.xAppInitiatedSSOToWebToken != null) {
+      query.append(
+        "x_app_initiated_sso_to_web_token",
+        options.xAppInitiatedSSOToWebToken
+      );
     }
     if (!this.isSSOEnabled) {
       // For backward compatibility

--- a/packages/authgear-core/src/error.ts
+++ b/packages/authgear-core/src/error.ts
@@ -141,3 +141,10 @@ export function _decodeError(err: any): Error {
   // Otherwise cast it to string and use it as message.
   return new Error(String(err));
 }
+
+/**
+ * NotAllowedError
+ *
+ * @public
+ */
+export class NotAllowedError extends AuthgearError {}

--- a/packages/authgear-core/src/error.ts
+++ b/packages/authgear-core/src/error.ts
@@ -143,8 +143,29 @@ export function _decodeError(err: any): Error {
 }
 
 /**
- * NotAllowedError
+ * AppInitiatedSSOToWebNotAllowedError
  *
  * @public
  */
-export class NotAllowedError extends AuthgearError {}
+export class AppInitiatedSSOToWebNotAllowedError extends AuthgearError {}
+
+/**
+ * AppInitiatedSSOToWebInsufficientScopeError
+ *
+ * @public
+ */
+export class AppInitiatedSSOToWebInsufficientScopeError extends AppInitiatedSSOToWebNotAllowedError {}
+
+/**
+ * AppInitiatedSSOToWebIDTokenNotFoundError
+ *
+ * @public
+ */
+export class AppInitiatedSSOToWebIDTokenNotFoundError extends AppInitiatedSSOToWebNotAllowedError {}
+
+/**
+ * AppInitiatedSSOToWebDeviceSecretNotFoundError
+ *
+ * @public
+ */
+export class AppInitiatedSSOToWebDeviceSecretNotFoundError extends AppInitiatedSSOToWebNotAllowedError {}

--- a/packages/authgear-core/src/error.ts
+++ b/packages/authgear-core/src/error.ts
@@ -143,29 +143,29 @@ export function _decodeError(err: any): Error {
 }
 
 /**
- * AppInitiatedSSOToWebNotAllowedError
+ * PreAuthenticatedURLNotAllowedError
  *
  * @public
  */
-export class AppInitiatedSSOToWebNotAllowedError extends AuthgearError {}
+export class PreAuthenticatedURLNotAllowedError extends AuthgearError {}
 
 /**
- * AppInitiatedSSOToWebInsufficientScopeError
+ * PreAuthenticatedURLInsufficientScopeError
  *
  * @public
  */
-export class AppInitiatedSSOToWebInsufficientScopeError extends AppInitiatedSSOToWebNotAllowedError {}
+export class PreAuthenticatedURLInsufficientScopeError extends PreAuthenticatedURLNotAllowedError {}
 
 /**
- * AppInitiatedSSOToWebIDTokenNotFoundError
+ * PreAuthenticatedURLIDTokenNotFoundError
  *
  * @public
  */
-export class AppInitiatedSSOToWebIDTokenNotFoundError extends AppInitiatedSSOToWebNotAllowedError {}
+export class PreAuthenticatedURLIDTokenNotFoundError extends PreAuthenticatedURLNotAllowedError {}
 
 /**
- * AppInitiatedSSOToWebDeviceSecretNotFoundError
+ * PreAuthenticatedURLDeviceSecretNotFoundError
  *
  * @public
  */
-export class AppInitiatedSSOToWebDeviceSecretNotFoundError extends AppInitiatedSSOToWebNotAllowedError {}
+export class PreAuthenticatedURLDeviceSecretNotFoundError extends PreAuthenticatedURLNotAllowedError {}

--- a/packages/authgear-core/src/storage.ts
+++ b/packages/authgear-core/src/storage.ts
@@ -13,6 +13,14 @@ export class _KeyMaker {
     return `${this.scopedKey(name)}_refreshToken`;
   }
 
+  keyIDToken(name: string): string {
+    return `${this.scopedKey(name)}_idToken`;
+  }
+
+  keyDeviceSecret(name: string): string {
+    return `${this.scopedKey(name)}_deviceSecret`;
+  }
+
   keyOIDCCodeVerifier(name: string): string {
     return `${this.scopedKey(name)}_oidcCodeVerifier`;
   }
@@ -110,12 +118,36 @@ export class TransientTokenStorage implements TokenStorage {
       refreshToken
     );
   }
-
   async getRefreshToken(namespace: string): Promise<string | null> {
     return this.storageDriver.get(this.keyMaker.keyRefreshToken(namespace));
   }
-
   async delRefreshToken(namespace: string): Promise<void> {
     await this.storageDriver.del(this.keyMaker.keyRefreshToken(namespace));
+  }
+
+  async setIDToken(namespace: string, idToken: string): Promise<void> {
+    return this.storageDriver.set(this.keyMaker.keyIDToken(namespace), idToken);
+  }
+  async getIDToken(namespace: string): Promise<string | null> {
+    return this.storageDriver.get(this.keyMaker.keyIDToken(namespace));
+  }
+  async delIDToken(namespace: string): Promise<void> {
+    return this.storageDriver.del(this.keyMaker.keyIDToken(namespace));
+  }
+
+  async setDeviceSecret(
+    namespace: string,
+    deviceSecret: string
+  ): Promise<void> {
+    return this.storageDriver.set(
+      this.keyMaker.keyDeviceSecret(namespace),
+      deviceSecret
+    );
+  }
+  async getDeviceSecret(namespace: string): Promise<string | null> {
+    return this.storageDriver.get(this.keyMaker.keyDeviceSecret(namespace));
+  }
+  async delDeviceSecret(namespace: string): Promise<void> {
+    return this.storageDriver.del(this.keyMaker.keyDeviceSecret(namespace));
   }
 }

--- a/packages/authgear-core/src/storage.ts
+++ b/packages/authgear-core/src/storage.ts
@@ -124,30 +124,4 @@ export class TransientTokenStorage implements TokenStorage {
   async delRefreshToken(namespace: string): Promise<void> {
     await this.storageDriver.del(this.keyMaker.keyRefreshToken(namespace));
   }
-
-  async setIDToken(namespace: string, idToken: string): Promise<void> {
-    return this.storageDriver.set(this.keyMaker.keyIDToken(namespace), idToken);
-  }
-  async getIDToken(namespace: string): Promise<string | null> {
-    return this.storageDriver.get(this.keyMaker.keyIDToken(namespace));
-  }
-  async delIDToken(namespace: string): Promise<void> {
-    return this.storageDriver.del(this.keyMaker.keyIDToken(namespace));
-  }
-
-  async setDeviceSecret(
-    namespace: string,
-    deviceSecret: string
-  ): Promise<void> {
-    return this.storageDriver.set(
-      this.keyMaker.keyDeviceSecret(namespace),
-      deviceSecret
-    );
-  }
-  async getDeviceSecret(namespace: string): Promise<string | null> {
-    return this.storageDriver.get(this.keyMaker.keyDeviceSecret(namespace));
-  }
-  async delDeviceSecret(namespace: string): Promise<void> {
-    return this.storageDriver.del(this.keyMaker.keyDeviceSecret(namespace));
-  }
 }

--- a/packages/authgear-core/src/types.ts
+++ b/packages/authgear-core/src/types.ts
@@ -74,7 +74,7 @@ export interface _OIDCAuthenticationRequest {
     | "code"
     | "none"
     | "urn:authgear:params:oauth:response-type:settings-action"
-    | "urn:authgear:params:oauth:response-type:app_initiated_sso_to_web token";
+    | "urn:authgear:params:oauth:response-type:pre-authenticated-url token";
   responseMode?: "cookie" | "query";
   scope?: string[];
   state?: string;
@@ -296,7 +296,7 @@ export interface _OIDCTokenRequest {
   x_device_info?: string;
   access_token?: string;
   scope?: string[];
-  requested_token_type?: "urn:authgear:params:oauth:token-type:app-initiated-sso-to-web-token";
+  requested_token_type?: "urn:authgear:params:oauth:token-type:pre-authenticated-url-token";
   subject_token_type?: "urn:ietf:params:oauth:token-type:id_token";
   subject_token?: string;
   actor_token_type?: "urn:x-oath:params:oauth:token-type:device-secret";
@@ -385,7 +385,7 @@ export enum SettingsAction {
 /**
  * @internal
  */
-export interface _AppInitiatedSSOToWebOptions {
+export interface _PreAuthenticatedURLOptions {
   /**
    * The client ID of the new authenticated session in web.
    */

--- a/packages/authgear-core/src/types.ts
+++ b/packages/authgear-core/src/types.ts
@@ -386,16 +386,7 @@ export enum SettingsAction {
  * @internal
  */
 export interface _PreAuthenticatedURLOptions {
-  /**
-   * The client ID of the new authenticated session in web.
-   */
-  clientID: string;
-  /**
-   * The URI the browser should go to after successfully obtained a authenticated session.
-   */
-  redirectURI: string;
-  /**
-   * Any string that will be passed to redirectURI by the `state` query parameter.
-   */
+  webApplicationClientID: string;
+  webApplicationURI: string;
   state?: string;
 }

--- a/packages/authgear-core/src/types.ts
+++ b/packages/authgear-core/src/types.ts
@@ -93,7 +93,7 @@ export interface _OIDCAuthenticationRequest {
   xSettingsAction?: "change_password";
   authenticationFlowGroup?: string;
   clientID?: string;
-  xAppInitiatedSSOToWebToken?: string;
+  xPreAuthenticatedURLToken?: string;
 }
 
 /**

--- a/packages/authgear-core/src/types.ts
+++ b/packages/authgear-core/src/types.ts
@@ -268,7 +268,8 @@ export interface _OIDCTokenRequest {
     | "urn:authgear:params:oauth:grant-type:anonymous-request"
     | "urn:authgear:params:oauth:grant-type:biometric-request"
     | "urn:authgear:params:oauth:grant-type:id-token"
-    | "urn:authgear:params:oauth:grant-type:settings-action";
+    | "urn:authgear:params:oauth:grant-type:settings-action"
+    | "urn:ietf:params:oauth:grant-type:token-exchange";
   client_id: string;
   redirect_uri?: string;
   code?: string;
@@ -277,6 +278,13 @@ export interface _OIDCTokenRequest {
   jwt?: string;
   x_device_info?: string;
   access_token?: string;
+  scope?: string[];
+  requested_token_type?: "urn:authgear:params:oauth:token-type:app-initiated-sso-to-web-token";
+  subject_token_type?: "urn:ietf:params:oauth:token-type:id_token";
+  subject_token?: string;
+  actor_token_type?: "urn:x-oath:params:oauth:token-type:device-secret";
+  actor_token?: string;
+  audience?: string;
 }
 
 /**
@@ -297,6 +305,7 @@ export interface _OIDCTokenResponse {
   access_token?: string;
   expires_in?: number;
   refresh_token?: string;
+  device_secret?: string;
 }
 
 /**

--- a/packages/authgear-core/src/types.ts
+++ b/packages/authgear-core/src/types.ts
@@ -73,8 +73,10 @@ export interface _OIDCAuthenticationRequest {
   responseType:
     | "code"
     | "none"
-    | "urn:authgear:params:oauth:response-type:settings-action";
-  scope: string[];
+    | "urn:authgear:params:oauth:response-type:settings-action"
+    | "urn:authgear:params:oauth:response-type:app_initiated_sso_to_web token";
+  responseMode?: "cookie" | "query";
+  scope?: string[];
   state?: string;
   xState?: string;
   prompt?: PromptOption[] | PromptOption;
@@ -90,6 +92,8 @@ export interface _OIDCAuthenticationRequest {
   oauthProviderAlias?: string;
   xSettingsAction?: "change_password";
   authenticationFlowGroup?: string;
+  clientID?: string;
+  xAppInitiatedSSOToWebToken?: string;
 }
 
 /**

--- a/packages/authgear-core/src/types.ts
+++ b/packages/authgear-core/src/types.ts
@@ -210,6 +210,14 @@ export interface TokenStorage {
   setRefreshToken(namespace: string, refreshToken: string): Promise<void>;
   getRefreshToken(namespace: string): Promise<string | null>;
   delRefreshToken(namespace: string): Promise<void>;
+
+  setIDToken(namespace: string, idToken: string): Promise<void>;
+  getIDToken(namespace: string): Promise<string | null>;
+  delIDToken(namespace: string): Promise<void>;
+
+  setDeviceSecret(namespace: string, deviceSecret: string): Promise<void>;
+  getDeviceSecret(namespace: string): Promise<string | null>;
+  delDeviceSecret(namespace: string): Promise<void>;
 }
 
 /**

--- a/packages/authgear-core/src/types.ts
+++ b/packages/authgear-core/src/types.ts
@@ -214,7 +214,12 @@ export interface TokenStorage {
   setRefreshToken(namespace: string, refreshToken: string): Promise<void>;
   getRefreshToken(namespace: string): Promise<string | null>;
   delRefreshToken(namespace: string): Promise<void>;
+}
 
+/**
+ * @internal
+ */
+export interface SharedStorage {
   setIDToken(namespace: string, idToken: string): Promise<void>;
   getIDToken(namespace: string): Promise<string | null>;
   delIDToken(namespace: string): Promise<void>;

--- a/packages/authgear-core/src/types.ts
+++ b/packages/authgear-core/src/types.ts
@@ -297,6 +297,7 @@ export interface _OIDCTokenRequest {
   actor_token_type?: "urn:x-oath:params:oauth:token-type:device-secret";
   actor_token?: string;
   audience?: string;
+  device_secret?: string;
 }
 
 /**

--- a/packages/authgear-core/src/types.ts
+++ b/packages/authgear-core/src/types.ts
@@ -376,3 +376,21 @@ export enum Page {
 export enum SettingsAction {
   ChangePassword = "change_password",
 }
+
+/**
+ * @internal
+ */
+export interface _AppInitiatedSSOToWebOptions {
+  /**
+   * The client ID of the new authenticated session in web.
+   */
+  clientID: string;
+  /**
+   * The URI the browser should go to after successfully obtained a authenticated session.
+   */
+  redirectURI: string;
+  /**
+   * Any string that will be passed to redirectURI by the `state` query parameter.
+   */
+  state?: string;
+}

--- a/packages/authgear-core/src/types.ts
+++ b/packages/authgear-core/src/types.ts
@@ -219,7 +219,7 @@ export interface TokenStorage {
 /**
  * @internal
  */
-export interface SharedStorage {
+export interface InterAppSharedStorage {
   setIDToken(namespace: string, idToken: string): Promise<void>;
   getIDToken(namespace: string): Promise<string | null>;
   delIDToken(namespace: string): Promise<void>;

--- a/packages/authgear-react-native/src/index.ts
+++ b/packages/authgear-react-native/src/index.ts
@@ -45,7 +45,7 @@ import {
   AuthenticateResult,
   ReauthenticateResult,
   SettingsActionOptions,
-  AppInitiatedSSOToWebOptions,
+  PreAuthenticatedURLOptions,
 } from "./types";
 import { getAnonymousJWK, signAnonymousJWT } from "./jwt";
 import { BiometricPrivateKeyNotFoundError } from "./error";
@@ -213,7 +213,7 @@ export class ReactNativeContainer {
   }
 
   /**
-   * Is App Initiated SSO To Web enabled
+   * Is Pre Authenticated URL enabled
    *
    * @public
    */
@@ -977,7 +977,7 @@ export class ReactNativeContainer {
    * @public
    */
   async makePreAuthenticatedURL(
-    options: AppInitiatedSSOToWebOptions
+    options: PreAuthenticatedURLOptions
   ): Promise<string> {
     return this.baseContainer._makePreAuthenticatedURL({ ...options });
   }

--- a/packages/authgear-react-native/src/index.ts
+++ b/packages/authgear-react-native/src/index.ts
@@ -16,9 +16,14 @@ import {
   Page,
   PromptOption,
   SettingsAction,
+  SharedStorage,
 } from "@authgear/core";
 import { Platform } from "react-native";
-import { PersistentContainerStorage, PersistentTokenStorage } from "./storage";
+import {
+  PersistentContainerStorage,
+  PersistentSharedStorage,
+  PersistentTokenStorage,
+} from "./storage";
 import { generateCodeVerifier, computeCodeChallenge } from "./pkce";
 import {
   registerWechatRedirectURI,
@@ -145,6 +150,13 @@ export class ReactNativeContainer {
   tokenStorage: TokenStorage;
 
   /**
+   * implements _BaseContainerDelegate
+   *
+   * @internal
+   */
+  sharedStorage: SharedStorage;
+
+  /**
    * @internal
    */
   uiImplementation: UIImplementation;
@@ -256,6 +268,7 @@ export class ReactNativeContainer {
 
     this.storage = new PersistentContainerStorage();
     this.tokenStorage = new PersistentTokenStorage();
+    this.sharedStorage = new PersistentSharedStorage();
     this.uiImplementation = new DeviceBrowserUIImplementation();
 
     this.wechatRedirectDeepLinkListener = (url: string) => {

--- a/packages/authgear-react-native/src/index.ts
+++ b/packages/authgear-react-native/src/index.ts
@@ -469,7 +469,7 @@ export class ReactNativeContainer {
       loginHint,
       idTokenHint: idToken,
       responseType: "urn:authgear:params:oauth:response-type:settings-action",
-      scope: ["openid", "https://authgear.com/scopes/full-access"],
+      scope: this.baseContainer.getSettingsActionScopes(),
       xSettingsAction: action,
     });
     if (options.wechatRedirectURI != null) {
@@ -526,7 +526,7 @@ export class ReactNativeContainer {
       maxAge,
       idTokenHint: idToken,
       responseType: "code",
-      scope: ["openid", "https://authgear.com/scopes/full-access"],
+      scope: this.baseContainer.getReauthenticateScopes(),
     });
 
     if (options.wechatRedirectURI != null) {
@@ -763,7 +763,9 @@ export class ReactNativeContainer {
     return this.baseContainer.authorizeEndpoint({
       ...options,
       responseType: "code",
-      scope: this.baseContainer.getScopes(),
+      scope: this.baseContainer.getAuthenticateScopes({
+        requestOfflineAccess: true,
+      }),
     });
   }
 
@@ -929,7 +931,9 @@ export class ReactNativeContainer {
           grant_type: "urn:authgear:params:oauth:grant-type:biometric-request",
           client_id: clientID,
           jwt,
-          scope: this.baseContainer.getScopes(),
+          scope: this.baseContainer.getAuthenticateScopes({
+            requestOfflineAccess: true,
+          }),
         });
 
       const userInfo = await this.baseContainer.apiClient._oidcUserInfoRequest(

--- a/packages/authgear-react-native/src/index.ts
+++ b/packages/authgear-react-native/src/index.ts
@@ -976,10 +976,10 @@ export class ReactNativeContainer {
    *
    * @public
    */
-  async makeAppInitiatedSSOToWebURL(
+  async makePreAuthenticatedURL(
     options: AppInitiatedSSOToWebOptions
   ): Promise<string> {
-    return this.baseContainer._makeAppInitiatedSSOToWebURL({ ...options });
+    return this.baseContainer._makePreAuthenticatedURL({ ...options });
   }
 }
 

--- a/packages/authgear-react-native/src/index.ts
+++ b/packages/authgear-react-native/src/index.ts
@@ -929,6 +929,7 @@ export class ReactNativeContainer {
           grant_type: "urn:authgear:params:oauth:grant-type:biometric-request",
           client_id: clientID,
           jwt,
+          scope: this.baseContainer.getScopes(),
         });
 
       const userInfo = await this.baseContainer.apiClient._oidcUserInfoRequest(

--- a/packages/authgear-react-native/src/index.ts
+++ b/packages/authgear-react-native/src/index.ts
@@ -94,10 +94,10 @@ export interface ConfigureOptions {
   isSSOEnabled?: boolean;
 
   /**
-   * When isAppInitiatedSSOToWebEnabled is true, native apps can share session with a web browser.
+   * When preAuthenticatedURLEnabled is true, native apps can share session with a web browser.
    * @defaultValue false
    */
-  isAppInitiatedSSOToWebEnabled?: boolean;
+  preAuthenticatedURLEnabled?: boolean;
 
   /*
    * The UIImplementation.
@@ -217,15 +217,12 @@ export class ReactNativeContainer {
    *
    * @public
    */
-  public get isAppInitiatedSSOToWebEnabled(): boolean {
-    return this.baseContainer.isAppInitiatedSSOToWebEnabled;
+  public get preAuthenticatedURLEnabled(): boolean {
+    return this.baseContainer.preAuthenticatedURLEnabled;
   }
 
-  public set isAppInitiatedSSOToWebEnabled(
-    isAppInitiatedSSOToWebEnabled: boolean
-  ) {
-    this.baseContainer.isAppInitiatedSSOToWebEnabled =
-      isAppInitiatedSSOToWebEnabled;
+  public set preAuthenticatedURLEnabled(preAuthenticatedURLEnabled: boolean) {
+    this.baseContainer.preAuthenticatedURLEnabled = preAuthenticatedURLEnabled;
   }
 
   /**
@@ -362,8 +359,8 @@ export class ReactNativeContainer {
    */
   async configure(options: ConfigureOptions): Promise<void> {
     this.isSSOEnabled = options.isSSOEnabled ?? false;
-    this.isAppInitiatedSSOToWebEnabled =
-      options.isAppInitiatedSSOToWebEnabled ?? false;
+    this.preAuthenticatedURLEnabled =
+      options.preAuthenticatedURLEnabled ?? false;
     if (options.tokenStorage != null) {
       this.tokenStorage = options.tokenStorage;
     } else {
@@ -975,7 +972,7 @@ export class ReactNativeContainer {
   /**
    * Share the current authenticated session to a web browser.
    *
-   * `isAppInitiatedSSOToWebEnabled` must be set to true to use this method.
+   * `preAuthenticatedURLEnabled` must be set to true to use this method.
    *
    * @public
    */

--- a/packages/authgear-react-native/src/index.ts
+++ b/packages/authgear-react-native/src/index.ts
@@ -16,12 +16,12 @@ import {
   Page,
   PromptOption,
   SettingsAction,
-  SharedStorage,
+  InterAppSharedStorage,
 } from "@authgear/core";
 import { Platform } from "react-native";
 import {
   PersistentContainerStorage,
-  PersistentSharedStorage,
+  PersistentInterAppSharedStorage,
   PersistentTokenStorage,
 } from "./storage";
 import { generateCodeVerifier, computeCodeChallenge } from "./pkce";
@@ -154,7 +154,7 @@ export class ReactNativeContainer {
    *
    * @internal
    */
-  sharedStorage: SharedStorage;
+  sharedStorage: InterAppSharedStorage;
 
   /**
    * @internal
@@ -268,7 +268,7 @@ export class ReactNativeContainer {
 
     this.storage = new PersistentContainerStorage();
     this.tokenStorage = new PersistentTokenStorage();
-    this.sharedStorage = new PersistentSharedStorage();
+    this.sharedStorage = new PersistentInterAppSharedStorage();
     this.uiImplementation = new DeviceBrowserUIImplementation();
 
     this.wechatRedirectDeepLinkListener = (url: string) => {

--- a/packages/authgear-react-native/src/index.ts
+++ b/packages/authgear-react-native/src/index.ts
@@ -40,6 +40,7 @@ import {
   AuthenticateResult,
   ReauthenticateResult,
   SettingsActionOptions,
+  AppInitiatedSSOToWebOptions,
 } from "./types";
 import { getAnonymousJWK, signAnonymousJWT } from "./jwt";
 import { BiometricPrivateKeyNotFoundError } from "./error";
@@ -86,6 +87,12 @@ export interface ConfigureOptions {
    * @defaultValue false
    */
   isSSOEnabled?: boolean;
+
+  /**
+   * When isAppInitiatedSSOToWebEnabled is true, native apps can share session with a web browser.
+   * @defaultValue false
+   */
+  isAppInitiatedSSOToWebEnabled?: boolean;
 
   /*
    * The UIImplementation.
@@ -191,6 +198,22 @@ export class ReactNativeContainer {
 
   public set isSSOEnabled(isSSOEnabled: boolean) {
     this.baseContainer.isSSOEnabled = isSSOEnabled;
+  }
+
+  /**
+   * Is App Initiated SSO To Web enabled
+   *
+   * @public
+   */
+  public get isAppInitiatedSSOToWebEnabled(): boolean {
+    return this.baseContainer.isAppInitiatedSSOToWebEnabled;
+  }
+
+  public set isAppInitiatedSSOToWebEnabled(
+    isAppInitiatedSSOToWebEnabled: boolean
+  ) {
+    this.baseContainer.isAppInitiatedSSOToWebEnabled =
+      isAppInitiatedSSOToWebEnabled;
   }
 
   /**
@@ -326,6 +349,8 @@ export class ReactNativeContainer {
    */
   async configure(options: ConfigureOptions): Promise<void> {
     this.isSSOEnabled = options.isSSOEnabled ?? false;
+    this.isAppInitiatedSSOToWebEnabled =
+      options.isAppInitiatedSSOToWebEnabled ?? false;
     if (options.tokenStorage != null) {
       this.tokenStorage = options.tokenStorage;
     } else {
@@ -738,11 +763,7 @@ export class ReactNativeContainer {
     return this.baseContainer.authorizeEndpoint({
       ...options,
       responseType: "code",
-      scope: [
-        "openid",
-        "offline_access",
-        "https://authgear.com/scopes/full-access",
-      ],
+      scope: this.baseContainer.getScopes(),
     });
   }
 
@@ -931,6 +952,19 @@ export class ReactNativeContainer {
       }
       throw e;
     }
+  }
+
+  /**
+   * Share the current authenticated session to a web browser.
+   *
+   * `isAppInitiatedSSOToWebEnabled` must be set to true to use this method.
+   *
+   * @public
+   */
+  async makeAppInitiatedSSOToWebURL(
+    options: AppInitiatedSSOToWebOptions
+  ): Promise<string> {
+    return this.baseContainer._makeAppInitiatedSSOToWebURL({ ...options });
   }
 }
 

--- a/packages/authgear-react-native/src/storage.ts
+++ b/packages/authgear-react-native/src/storage.ts
@@ -4,7 +4,7 @@ import {
   _ContainerStorage,
   _KeyMaker,
   _SafeStorageDriver,
-  SharedStorage,
+  InterAppSharedStorage,
 } from "@authgear/core";
 import {
   storageGetItem,
@@ -65,7 +65,7 @@ export class PersistentTokenStorage implements TokenStorage {
 /**
  * @internal
  */
-export class PersistentSharedStorage implements SharedStorage {
+export class PersistentInterAppSharedStorage implements InterAppSharedStorage {
   private keyMaker: _KeyMaker;
   private storageDriver: _StorageDriver;
 

--- a/packages/authgear-react-native/src/storage.ts
+++ b/packages/authgear-react-native/src/storage.ts
@@ -4,6 +4,7 @@ import {
   _ContainerStorage,
   _KeyMaker,
   _SafeStorageDriver,
+  SharedStorage,
 } from "@authgear/core";
 import {
   storageGetItem,
@@ -58,6 +59,19 @@ export class PersistentTokenStorage implements TokenStorage {
   }
   async delRefreshToken(namespace: string): Promise<void> {
     await this.storageDriver.del(this.keyMaker.keyRefreshToken(namespace));
+  }
+}
+
+/**
+ * @internal
+ */
+export class PersistentSharedStorage implements SharedStorage {
+  private keyMaker: _KeyMaker;
+  private storageDriver: _StorageDriver;
+
+  constructor() {
+    this.keyMaker = new _KeyMaker();
+    this.storageDriver = new _SafeStorageDriver(new _PlatformStorageDriver());
   }
 
   async setIDToken(namespace: string, idToken: string): Promise<void> {

--- a/packages/authgear-react-native/src/storage.ts
+++ b/packages/authgear-react-native/src/storage.ts
@@ -53,13 +53,37 @@ export class PersistentTokenStorage implements TokenStorage {
       refreshToken
     );
   }
-
   async getRefreshToken(namespace: string): Promise<string | null> {
     return this.storageDriver.get(this.keyMaker.keyRefreshToken(namespace));
   }
-
   async delRefreshToken(namespace: string): Promise<void> {
     await this.storageDriver.del(this.keyMaker.keyRefreshToken(namespace));
+  }
+
+  async setIDToken(namespace: string, idToken: string): Promise<void> {
+    return this.storageDriver.set(this.keyMaker.keyIDToken(namespace), idToken);
+  }
+  async getIDToken(namespace: string): Promise<string | null> {
+    return this.storageDriver.get(this.keyMaker.keyIDToken(namespace));
+  }
+  async delIDToken(namespace: string): Promise<void> {
+    return this.storageDriver.del(this.keyMaker.keyIDToken(namespace));
+  }
+
+  async setDeviceSecret(
+    namespace: string,
+    deviceSecret: string
+  ): Promise<void> {
+    return this.storageDriver.set(
+      this.keyMaker.keyDeviceSecret(namespace),
+      deviceSecret
+    );
+  }
+  async getDeviceSecret(namespace: string): Promise<string | null> {
+    return this.storageDriver.get(this.keyMaker.keyDeviceSecret(namespace));
+  }
+  async delDeviceSecret(namespace: string): Promise<void> {
+    return this.storageDriver.del(this.keyMaker.keyDeviceSecret(namespace));
   }
 }
 

--- a/packages/authgear-react-native/src/types.ts
+++ b/packages/authgear-react-native/src/types.ts
@@ -427,11 +427,11 @@ export interface BiometricPrivateKeyOptions extends BiometricOptions {
 }
 
 /**
- * AppInitiatedSSOToWebOptions is options for app-initiated-sso-to-web.
+ * PreAuthenticatedURLOptions is options for pre-authenticated-url.
  *
  * @public
  */
-export interface AppInitiatedSSOToWebOptions {
+export interface PreAuthenticatedURLOptions {
   /**
    * The client ID of the new authenticated session in web.
    */

--- a/packages/authgear-react-native/src/types.ts
+++ b/packages/authgear-react-native/src/types.ts
@@ -425,3 +425,23 @@ export interface BiometricPrivateKeyOptions extends BiometricOptions {
     device_info: unknown;
   };
 }
+
+/**
+ * AppInitiatedSSOToWebOptions is options for app-initiated-sso-to-web.
+ *
+ * @public
+ */
+export interface AppInitiatedSSOToWebOptions {
+  /**
+   * The client ID of the new authenticated session in web.
+   */
+  clientID: string;
+  /**
+   * The URI the browser should go to after successfully obtained a authenticated session.
+   */
+  redirectURI: string;
+  /**
+   * Any string that will be passed to redirectURI by the `state` query parameter.
+   */
+  state?: string;
+}

--- a/packages/authgear-react-native/src/types.ts
+++ b/packages/authgear-react-native/src/types.ts
@@ -433,15 +433,15 @@ export interface BiometricPrivateKeyOptions extends BiometricOptions {
  */
 export interface PreAuthenticatedURLOptions {
   /**
-   * The client ID of the new authenticated session in web.
+   * The client ID of the web application.
    */
-  clientID: string;
+  webApplicationClientID: string;
   /**
    * The URI the browser should go to after successfully obtained a authenticated session.
    */
-  redirectURI: string;
+  webApplicationURI: string;
   /**
-   * Any string that will be passed to redirectURI by the `state` query parameter.
+   * Any string that will be passed to webApplicationURI by the `state` query parameter.
    */
   state?: string;
 }

--- a/packages/authgear-web/src/container.ts
+++ b/packages/authgear-web/src/container.ts
@@ -363,7 +363,7 @@ export class WebContainer {
         loginHint,
         idTokenHint: idToken,
         responseType: "urn:authgear:params:oauth:response-type:settings-action",
-        scope: ["openid", "https://authgear.com/scopes/full-access"],
+        scope: this.baseContainer.getSettingsActionScopes(),
         xSettingsAction: action,
       });
       window.location.href = endpoint;
@@ -396,7 +396,7 @@ export class WebContainer {
       maxAge,
       idTokenHint: idToken,
       responseType: "code",
-      scope: ["openid", "https://authgear.com/scopes/full-access"],
+      scope: this.baseContainer.getReauthenticateScopes(),
     });
     window.location.href = endpoint;
   }
@@ -683,14 +683,9 @@ export class WebContainer {
     // Use shared session cookie by default for first-party web apps.
     const responseType =
       options.responseType ?? this.sessionType === "cookie" ? "none" : "code";
-    const scope =
-      this.sessionType === "cookie"
-        ? ["openid", "https://authgear.com/scopes/full-access"]
-        : [
-            "openid",
-            "offline_access",
-            "https://authgear.com/scopes/full-access",
-          ];
+    const scope = this.baseContainer.getAuthenticateScopes({
+      requestOfflineAccess: this.sessionType === "refresh_token",
+    });
 
     const suppressIDPSessionCookie = this.sessionType === "refresh_token";
 

--- a/packages/authgear-web/src/container.ts
+++ b/packages/authgear-web/src/container.ts
@@ -12,13 +12,13 @@ import {
   Page,
   PromptOption,
   SettingsAction,
-  SharedStorage,
+  InterAppSharedStorage,
 } from "@authgear/core";
 import { _WebAPIClient } from "./client";
 import {
   PersistentTokenStorage,
   PersistentContainerStorage,
-  PersistentSharedStorage,
+  PersistentInterAppSharedStorage,
 } from "./storage";
 import { generateCodeVerifier, computeCodeChallenge } from "./pkce";
 import {
@@ -102,7 +102,7 @@ export class WebContainer {
   /**
    * @internal
    */
-  sharedStorage: SharedStorage;
+  sharedStorage: InterAppSharedStorage;
 
   /**
    * @public
@@ -191,7 +191,7 @@ export class WebContainer {
 
     this.storage = new PersistentContainerStorage();
     this.tokenStorage = new PersistentTokenStorage();
-    this.sharedStorage = new PersistentSharedStorage();
+    this.sharedStorage = new PersistentInterAppSharedStorage();
 
     this.sessionType = "refresh_token";
   }

--- a/packages/authgear-web/src/container.ts
+++ b/packages/authgear-web/src/container.ts
@@ -12,9 +12,14 @@ import {
   Page,
   PromptOption,
   SettingsAction,
+  SharedStorage,
 } from "@authgear/core";
 import { _WebAPIClient } from "./client";
-import { PersistentTokenStorage, PersistentContainerStorage } from "./storage";
+import {
+  PersistentTokenStorage,
+  PersistentContainerStorage,
+  PersistentSharedStorage,
+} from "./storage";
 import { generateCodeVerifier, computeCodeChallenge } from "./pkce";
 import {
   WebContainerDelegate,
@@ -93,6 +98,11 @@ export class WebContainer {
    * @internal
    */
   tokenStorage: TokenStorage;
+
+  /**
+   * @internal
+   */
+  sharedStorage: SharedStorage;
 
   /**
    * @public
@@ -181,6 +191,7 @@ export class WebContainer {
 
     this.storage = new PersistentContainerStorage();
     this.tokenStorage = new PersistentTokenStorage();
+    this.sharedStorage = new PersistentSharedStorage();
 
     this.sessionType = "refresh_token";
   }

--- a/packages/authgear-web/src/storage.ts
+++ b/packages/authgear-web/src/storage.ts
@@ -5,6 +5,7 @@ import {
   _ContainerStorage,
   _KeyMaker,
   _SafeStorageDriver,
+  SharedStorage,
 } from "@authgear/core";
 
 const _localStorageStorageDriver: _StorageDriver = {
@@ -51,6 +52,19 @@ export class PersistentTokenStorage implements TokenStorage {
   }
   async delRefreshToken(namespace: string): Promise<void> {
     await this.storageDriver.del(this.keyMaker.keyRefreshToken(namespace));
+  }
+}
+
+/**
+ * @internal
+ */
+export class PersistentSharedStorage implements SharedStorage {
+  private keyMaker: _KeyMaker;
+  private storageDriver: _StorageDriver;
+
+  constructor() {
+    this.keyMaker = new _KeyMaker();
+    this.storageDriver = new _SafeStorageDriver(_localStorageStorageDriver);
   }
 
   async setIDToken(namespace: string, idToken: string): Promise<void> {

--- a/packages/authgear-web/src/storage.ts
+++ b/packages/authgear-web/src/storage.ts
@@ -46,13 +46,37 @@ export class PersistentTokenStorage implements TokenStorage {
       refreshToken
     );
   }
-
   async getRefreshToken(namespace: string): Promise<string | null> {
     return this.storageDriver.get(this.keyMaker.keyRefreshToken(namespace));
   }
-
   async delRefreshToken(namespace: string): Promise<void> {
     await this.storageDriver.del(this.keyMaker.keyRefreshToken(namespace));
+  }
+
+  async setIDToken(namespace: string, idToken: string): Promise<void> {
+    return this.storageDriver.set(this.keyMaker.keyIDToken(namespace), idToken);
+  }
+  async getIDToken(namespace: string): Promise<string | null> {
+    return this.storageDriver.get(this.keyMaker.keyIDToken(namespace));
+  }
+  async delIDToken(namespace: string): Promise<void> {
+    return this.storageDriver.del(this.keyMaker.keyIDToken(namespace));
+  }
+
+  async setDeviceSecret(
+    namespace: string,
+    deviceSecret: string
+  ): Promise<void> {
+    return this.storageDriver.set(
+      this.keyMaker.keyDeviceSecret(namespace),
+      deviceSecret
+    );
+  }
+  async getDeviceSecret(namespace: string): Promise<string | null> {
+    return this.storageDriver.get(this.keyMaker.keyDeviceSecret(namespace));
+  }
+  async delDeviceSecret(namespace: string): Promise<void> {
+    return this.storageDriver.del(this.keyMaker.keyDeviceSecret(namespace));
   }
 }
 

--- a/packages/authgear-web/src/storage.ts
+++ b/packages/authgear-web/src/storage.ts
@@ -5,7 +5,7 @@ import {
   _ContainerStorage,
   _KeyMaker,
   _SafeStorageDriver,
-  SharedStorage,
+  InterAppSharedStorage,
 } from "@authgear/core";
 
 const _localStorageStorageDriver: _StorageDriver = {
@@ -58,7 +58,7 @@ export class PersistentTokenStorage implements TokenStorage {
 /**
  * @internal
  */
-export class PersistentSharedStorage implements SharedStorage {
+export class PersistentInterAppSharedStorage implements InterAppSharedStorage {
   private keyMaker: _KeyMaker;
   private storageDriver: _StorageDriver;
 


### PR DESCRIPTION
ref DEV-1407

## How to test

1. You should have two clients, for example `client1id` `client2id`. Set `x_app_initiated_sso_to_web_enabled` to true for both clients.
2. In the example app, fill `client1id` as the "Client ID". Fill `client2id` as the "App Initiated SSO To Web Client ID". Check "Is App Initiated SSO To Web Enabled". Press configure.
3. Press Authenticate and complete the login.
4. Now, press "App Initiated SSO To Web". You should see a browser opened and closed immediately. Then a continue screen appear.
5. Press continue, successfully logged in.