### PR TITLE
update sdk reference

### DIFF
--- a/packages/authgear-capacitor/src/types.ts
+++ b/packages/authgear-capacitor/src/types.ts
@@ -49,6 +49,7 @@ export interface AuthenticateOptions {
    */
   prompt?: PromptOption[] | PromptOption;
   /**
+   * @internal
    * OIDC login hint parameter
    */
   loginHint?: string;
@@ -68,6 +69,7 @@ export interface AuthenticateOptions {
   colorScheme?: ColorScheme;
 
   /**
+   * @internal
    * OAuth response type
    */
   responseType?: "code" | "none";

--- a/packages/authgear-capacitor/src/types.ts
+++ b/packages/authgear-capacitor/src/types.ts
@@ -49,8 +49,8 @@ export interface AuthenticateOptions {
    */
   prompt?: PromptOption[] | PromptOption;
   /**
-   * @internal
    * OIDC login hint parameter
+   * @internal
    */
   loginHint?: string;
   /**
@@ -69,8 +69,8 @@ export interface AuthenticateOptions {
   colorScheme?: ColorScheme;
 
   /**
-   * @internal
    * OAuth response type
+   * @internal
    */
   responseType?: "code" | "none";
 

--- a/packages/authgear-react-native/src/types.ts
+++ b/packages/authgear-react-native/src/types.ts
@@ -62,8 +62,8 @@ export interface AuthenticateOptions {
    */
   prompt?: PromptOption[] | PromptOption;
   /**
-   * @internal
    * OIDC login hint parameter
+   * @internal
    */
   loginHint?: string;
   /**
@@ -82,8 +82,8 @@ export interface AuthenticateOptions {
   colorScheme?: ColorScheme;
 
   /**
-   * @internal
    * OAuth response type
+   * @internal
    */
   responseType?: "code" | "none";
   /**

--- a/packages/authgear-react-native/src/types.ts
+++ b/packages/authgear-react-native/src/types.ts
@@ -62,6 +62,7 @@ export interface AuthenticateOptions {
    */
   prompt?: PromptOption[] | PromptOption;
   /**
+   * @internal
    * OIDC login hint parameter
    */
   loginHint?: string;
@@ -81,6 +82,7 @@ export interface AuthenticateOptions {
   colorScheme?: ColorScheme;
 
   /**
+   * @internal
    * OAuth response type
    */
   responseType?: "code" | "none";

--- a/packages/authgear-web/src/types.ts
+++ b/packages/authgear-web/src/types.ts
@@ -97,8 +97,8 @@ export interface AuthenticateOptions {
    */
   prompt?: PromptOption[] | PromptOption;
   /**
-   * @internal
    * OIDC login hint parameter
+   * @internal
    */
   loginHint?: string;
   /**
@@ -111,8 +111,8 @@ export interface AuthenticateOptions {
    */
   uiLocales?: string[];
   /**
-   * @internal
    * OAuth response type
+   * @internal
    */
   responseType?: "code" | "none";
   /**
@@ -217,8 +217,8 @@ export interface PromoteOptions {
    */
   uiLocales?: string[];
   /**
-   * @internal
    * OAuth response type
+   * @internal
    */
   responseType?: "code" | "none";
 }

--- a/packages/authgear-web/src/types.ts
+++ b/packages/authgear-web/src/types.ts
@@ -38,7 +38,9 @@ export interface ReauthenticateOptions {
    */
   state?: string;
   /**
-   * Custom state.
+   * Custom state. Use this parameter to provide parameters from the client application to Custom UI. The string in xState can be accessed by the Custom UI. 
+   * 
+   * Ignore this parameter if default AuthUI is used.
    */
   xState?: string;
   /**
@@ -76,7 +78,9 @@ export interface AuthenticateOptions {
    */
   state?: string;
   /**
-   * Custom state.
+   * Custom state. Use this parameter to provide parameters from the client application to Custom UI. The string in xState can be accessed by the Custom UI. 
+   * 
+   * Ignore this parameter if default AuthUI is used.
    */
   xState?: string;
   /**
@@ -93,6 +97,7 @@ export interface AuthenticateOptions {
    */
   prompt?: PromptOption[] | PromptOption;
   /**
+   * @internal
    * OIDC login hint parameter
    */
   loginHint?: string;
@@ -106,6 +111,7 @@ export interface AuthenticateOptions {
    */
   uiLocales?: string[];
   /**
+   * @internal
    * OAuth response type
    */
   responseType?: "code" | "none";
@@ -163,7 +169,9 @@ export interface SettingsActionOptions {
    */
   state?: string;
   /**
-   * Custom state.
+   * Custom state. Use this parameter to provide parameters from the client application to Custom UI. The string in xState can be accessed by the Custom UI.
+   * 
+   * Ignore this parameter if default AuthUI is used.
    */
   xState?: string;
   /**
@@ -194,7 +202,9 @@ export interface PromoteOptions {
    */
   state?: string;
   /**
-   * Custom state.
+   * Custom state. Use this parameter to provide parameters from the client application to Custom UI. The string in xState can be accessed by the Custom UI. 
+   * 
+   * Ignore this parameter if default AuthUI is used.
    */
   xState?: string;
   /**
@@ -207,6 +217,7 @@ export interface PromoteOptions {
    */
   uiLocales?: string[];
   /**
+   * @internal
    * OAuth response type
    */
   responseType?: "code" | "none";


### PR DESCRIPTION
This pull request is based on the issue "Clarify authentication options in SDK references"

It adds a description for "xState" and hides reference for 'loginHint", "responseType".

