### PR TITLE
Ensure access token is cleared on each configure

### DIFF
--- a/packages/authgear-capacitor/src/index.ts
+++ b/packages/authgear-capacitor/src/index.ts
@@ -375,6 +375,7 @@ export class CapacitorContainer {
     this.clientID = options.clientID;
     this.baseContainer.apiClient.endpoint = options.endpoint;
     this.baseContainer.refreshToken = refreshToken ?? undefined;
+    this.baseContainer.accessToken = undefined;
 
     if (this.baseContainer.refreshToken != null) {
       // consider user as logged in if refresh token is available

--- a/packages/authgear-react-native/src/index.ts
+++ b/packages/authgear-react-native/src/index.ts
@@ -412,6 +412,7 @@ export class ReactNativeContainer {
     this.clientID = options.clientID;
     this.baseContainer.apiClient.endpoint = options.endpoint;
     this.baseContainer.refreshToken = refreshToken ?? undefined;
+    this.baseContainer.accessToken = undefined;
 
     if (this.baseContainer.refreshToken != null) {
       // consider user as logged in if refresh token is available

--- a/packages/authgear-web/src/container.ts
+++ b/packages/authgear-web/src/container.ts
@@ -303,6 +303,7 @@ export class WebContainer {
         // and the previously stored refresh token is loaded.
         const refreshToken = await this.tokenStorage.getRefreshToken(this.name);
         this.baseContainer.refreshToken = refreshToken ?? undefined;
+        this.baseContainer.accessToken = undefined;
 
         if (this.baseContainer.refreshToken != null) {
           // consider user as logged in if refresh token is available


### PR DESCRIPTION
This is not related to the issue, but it causes some bugs in the demo app that after switching to transient token storage, you can fetch user info without login.