### PR TITLE
Clear session on invalid_dpop_proof during token refresh

### DIFF
--- a/example/capacitor/src/pages/Home.tsx
+++ b/example/capacitor/src/pages/Home.tsx
@@ -645,6 +645,35 @@ function AuthgearDemo() {
     }
   }, [showError, showUserInfo]);
 
+  // Unlike fetchUserInfo(), this does NOT chain any follow-up request
+  // after refresh, so the refresh result (e.g. invalid_grant vs
+  // invalid_dpop_proof) is not masked by a subsequent request made with a
+  // stale/missing access token.
+  const refreshAccessToken = useCallback(async () => {
+    setLoading(true);
+    try {
+      if (isPlatformWeb()) {
+        await authgearWeb.refreshAccessTokenIfNeeded();
+        setIsAlertOpen(true);
+        setAlertHeader("Refresh Access Token If Needed");
+        setAlertMessage(
+          `Refreshed access token successfully.\nsessionState: ${authgearWeb.sessionState}`
+        );
+      } else {
+        await authgearCapacitor.refreshAccessTokenIfNeeded();
+        setIsAlertOpen(true);
+        setAlertHeader("Refresh Access Token If Needed");
+        setAlertMessage(
+          `Refreshed access token successfully.\nsessionState: ${authgearCapacitor.sessionState}`
+        );
+      }
+    } catch (e) {
+      showError(e);
+    } finally {
+      setLoading(false);
+    }
+  }, [showError]);
+
   const logout = useCallback(async () => {
     setLoading(true);
     try {
@@ -947,6 +976,16 @@ function AuthgearDemo() {
     [fetchUserInfo]
   );
 
+  const onClickRefreshAccessToken = useCallback(
+    (e: MouseEvent<HTMLIonButtonElement>) => {
+      e.preventDefault();
+      e.stopPropagation();
+
+      refreshAccessToken();
+    },
+    [refreshAccessToken]
+  );
+
   const onClickShowAuthTime = useCallback(
     (e: MouseEvent<HTMLIonButtonElement>) => {
       e.preventDefault();
@@ -1224,6 +1263,13 @@ function AuthgearDemo() {
           onClick={onClickFetchUserInfo}
         >
           Fetch User Info
+        </IonButton>
+        <IonButton
+          className="button"
+          disabled={!initialized || loading || !loggedIn}
+          onClick={onClickRefreshAccessToken}
+        >
+          Refresh Access Token If Needed
         </IonButton>
         <IonButton
           className="button"

--- a/example/capacitor/src/pages/Home.tsx
+++ b/example/capacitor/src/pages/Home.tsx
@@ -39,6 +39,7 @@ import authgearCapacitor, {
   TransientTokenStorage,
   PersistentTokenStorage,
   CancelError as CapacitorCancelError,
+  OAuthError,
   ColorScheme,
   Page as CapacitorPage,
   BiometricOptions,
@@ -174,6 +175,13 @@ function AuthgearDemo() {
           "error=",
           error
         );
+        if (error instanceof OAuthError) {
+          if (error.error === "invalid_grant") {
+            console.log("onSessionStateChange: error is invalid_grant");
+          } else if (error.error === "invalid_dpop_proof") {
+            console.log("onSessionStateChange: error is invalid_dpop_proof");
+          }
+        }
         setSessionState(container.sessionState);
       },
     };

--- a/example/capacitor/src/pages/Home.tsx
+++ b/example/capacitor/src/pages/Home.tsx
@@ -164,8 +164,16 @@ function AuthgearDemo() {
     const d = {
       onSessionStateChange: (
         container: WebContainer | CapacitorContainer,
-        _reason: SessionStateChangeReason
+        reason: SessionStateChangeReason,
+        error?: unknown
       ) => {
+        console.log(
+          "onSessionStateChange",
+          "sessionState=" + container.sessionState,
+          "reason=" + reason,
+          "error=",
+          error
+        );
         setSessionState(container.sessionState);
       },
     };

--- a/example/reactnative/src/screens/MainScreen.tsx
+++ b/example/reactnative/src/screens/MainScreen.tsx
@@ -767,6 +767,26 @@ const HomeScreen: React.FC = () => {
       });
   }, [showError, showUser]);
 
+  // Unlike fetchUserInfo(), this does NOT chain any follow-up request
+  // after refresh, so the refresh result (e.g. invalid_grant vs
+  // invalid_dpop_proof) is not masked by a subsequent request made with a
+  // stale/missing access token.
+  const refreshAccessToken = useCallback(() => {
+    setLoading(true);
+    authgear
+      .refreshAccessTokenIfNeeded()
+      .then(() => {
+        Alert.alert(
+          'Refresh Access Token If Needed',
+          `Refreshed access token successfully.\nsessionState: ${authgear.sessionState}`,
+        );
+      })
+      .catch(e => showError(e))
+      .finally(() => {
+        setLoading(false);
+      });
+  }, [showError]);
+
   const showAuthTime = useCallback(() => {
     Alert.alert('auth_time', `${authgear.getAuthTime()}`);
   }, []);
@@ -1075,6 +1095,13 @@ const HomeScreen: React.FC = () => {
           <Button
             title="Fetch User Info"
             onPress={fetchUserInfo}
+            disabled={!initialized || loading || !loggedIn}
+          />
+        </View>
+        <View style={styles.button}>
+          <Button
+            title="Refresh Access Token If Needed"
+            onPress={refreshAccessToken}
             disabled={!initialized || loading || !loggedIn}
           />
         </View>

--- a/example/reactnative/src/screens/MainScreen.tsx
+++ b/example/reactnative/src/screens/MainScreen.tsx
@@ -334,8 +334,16 @@ const HomeScreen: React.FC = () => {
     const d: ReactNativeContainerDelegate = {
       onSessionStateChange: (
         container: ReactNativeContainer,
-        _reason: SessionStateChangeReason,
+        reason: SessionStateChangeReason,
+        error?: unknown,
       ) => {
+        console.log(
+          'onSessionStateChange',
+          'sessionState=' + container.sessionState,
+          'reason=' + reason,
+          'error=',
+          error,
+        );
         setSessionState(container.sessionState);
         if (container.sessionState !== 'AUTHENTICATED') {
           setUserInfo(null);

--- a/example/reactnative/src/screens/MainScreen.tsx
+++ b/example/reactnative/src/screens/MainScreen.tsx
@@ -19,6 +19,7 @@ import authgear, {
   SessionStateChangeReason,
   UserInfo,
   CancelError,
+  OAuthError,
   BiometricPrivateKeyNotFoundError,
   BiometricNotSupportedOrPermissionDeniedError,
   BiometricNoEnrollmentError,
@@ -344,6 +345,13 @@ const HomeScreen: React.FC = () => {
           'error=',
           error,
         );
+        if (error instanceof OAuthError) {
+          if (error.error === 'invalid_grant') {
+            console.log('onSessionStateChange: error is invalid_grant');
+          } else if (error.error === 'invalid_dpop_proof') {
+            console.log('onSessionStateChange: error is invalid_dpop_proof');
+          }
+        }
         setSessionState(container.sessionState);
         if (container.sessionState !== 'AUTHENTICATED') {
           setUserInfo(null);

--- a/example/reactweb/src/App.tsx
+++ b/example/reactweb/src/App.tsx
@@ -181,7 +181,14 @@ function Root() {
 
   const delegate: WebContainerDelegate = useMemo(() => {
     return {
-      onSessionStateChange(container, _) {
+      onSessionStateChange(container, reason, error) {
+        console.log(
+          "onSessionStateChange",
+          "sessionState=" + container.sessionState,
+          "reason=" + reason,
+          "error=",
+          error
+        );
         setSessionState(container.sessionState);
       },
     };

--- a/example/reactweb/src/App.tsx
+++ b/example/reactweb/src/App.tsx
@@ -9,6 +9,7 @@ import authgear, {
   LinkOAuthOptions,
   UnlinkOAuthOptions,
   IdentityType,
+  OAuthError,
 } from "@authgear/web";
 import "./App.css";
 
@@ -189,6 +190,11 @@ function Root() {
           "error=",
           error
         );
+        // Web does not implement DPoP, so invalid_dpop_proof cannot occur
+        // here -- only invalid_grant is relevant.
+        if (error instanceof OAuthError && error.error === "invalid_grant") {
+          console.log("onSessionStateChange: error is invalid_grant");
+        }
         setSessionState(container.sessionState);
       },
     };

--- a/packages/authgear-capacitor/src/index.ts
+++ b/packages/authgear-capacitor/src/index.ts
@@ -312,8 +312,11 @@ export class CapacitorContainer {
    *
    * @internal
    */
-  onSessionStateChange(reason: SessionStateChangeReason): void {
-    this.delegate?.onSessionStateChange(this, reason);
+  onSessionStateChange(
+    reason: SessionStateChangeReason,
+    error?: unknown
+  ): void {
+    this.delegate?.onSessionStateChange(this, reason, error);
   }
 
   /**

--- a/packages/authgear-capacitor/src/types.ts
+++ b/packages/authgear-capacitor/src/types.ts
@@ -16,11 +16,16 @@ export interface CapacitorContainerDelegate {
    * For example, when the user logs out, the new state is "NO_SESSION"
    * and the reason is "LOGOUT".
    *
+   * error is non-null when reason is "INVALID", i.e. the session was
+   * cleared because a request failed with an error such as invalid_grant
+   * or invalid_dpop_proof. It is undefined for all other reasons.
+   *
    * @public
    */
   onSessionStateChange: (
     container: CapacitorContainer,
-    reason: SessionStateChangeReason
+    reason: SessionStateChangeReason,
+    error?: unknown
   ) => void;
 }
 

--- a/packages/authgear-core/src/container.ts
+++ b/packages/authgear-core/src/container.ts
@@ -258,8 +258,15 @@ export class _BaseContainer<T extends _BaseAPIClient> {
     // When the error is `invalid_grant`, the refresh token is no longer valid.
     // Clear the session in this case.
     // https://tools.ietf.org/html/rfc6749#section-5.2
+    //
+    // `invalid_dpop_proof` on refresh means the DPoP key no longer matches the
+    // key the refresh token is bound to (e.g. restored from a device backup),
+    // so the refresh token is unusable and should be treated the same way.
     if (error != null) {
-      if (error.error === "invalid_grant") {
+      if (
+        error.error === "invalid_grant" ||
+        error.error === "invalid_dpop_proof"
+      ) {
         await this._clearSession(SessionStateChangeReason.Invalid);
       } else if (error.reason === "InvalidGrant") {
         await this._clearSession(SessionStateChangeReason.Invalid);
@@ -355,7 +362,11 @@ export class _BaseContainer<T extends _BaseAPIClient> {
       tokenResponse = await this.apiClient._oidcTokenRequest(request);
     } catch (error: unknown) {
       await this._handleInvalidGrantError(error);
-      if (error != null && (error as any).error === "invalid_grant") {
+      if (
+        error != null &&
+        ((error as any).error === "invalid_grant" ||
+          (error as any).error === "invalid_dpop_proof")
+      ) {
         return;
       }
 

--- a/packages/authgear-core/src/container.ts
+++ b/packages/authgear-core/src/container.ts
@@ -56,7 +56,13 @@ export interface _BaseContainerDelegate {
     challenge: string;
   }>;
   refreshAccessToken(): Promise<void>;
-  onSessionStateChange: (reason: SessionStateChangeReason) => void;
+  // error is non-null when reason is Invalid, i.e. the session was cleared
+  // because a request failed with an error such as invalid_grant or
+  // invalid_dpop_proof. It is undefined for all other reasons.
+  onSessionStateChange: (
+    reason: SessionStateChangeReason,
+    error?: unknown
+  ) => void;
 }
 
 /**
@@ -244,14 +250,17 @@ export class _BaseContainer<T extends _BaseAPIClient> {
     }
   }
 
-  async _clearSession(reason: SessionStateChangeReason): Promise<void> {
+  async _clearSession(
+    reason: SessionStateChangeReason,
+    error?: unknown
+  ): Promise<void> {
     await this._delegate.tokenStorage.delRefreshToken(this.name);
     await this._delegate.sharedStorage.onLogout(this.name);
     this.idToken = undefined;
     this.accessToken = undefined;
     this.refreshToken = undefined;
     this.expireAt = undefined;
-    this._updateSessionState(SessionState.NoSession, reason);
+    this._updateSessionState(SessionState.NoSession, reason, error);
   }
 
   async _handleInvalidGrantError(error: any): Promise<void> {
@@ -267,9 +276,9 @@ export class _BaseContainer<T extends _BaseAPIClient> {
         error.error === "invalid_grant" ||
         error.error === "invalid_dpop_proof"
       ) {
-        await this._clearSession(SessionStateChangeReason.Invalid);
+        await this._clearSession(SessionStateChangeReason.Invalid, error);
       } else if (error.reason === "InvalidGrant") {
-        await this._clearSession(SessionStateChangeReason.Invalid);
+        await this._clearSession(SessionStateChangeReason.Invalid, error);
       }
     }
   }
@@ -706,10 +715,11 @@ export class _BaseContainer<T extends _BaseAPIClient> {
    */
   _updateSessionState(
     state: SessionState,
-    reason: SessionStateChangeReason
+    reason: SessionStateChangeReason,
+    error?: unknown
   ): void {
     this.sessionState = state;
-    this._delegate.onSessionStateChange(reason);
+    this._delegate.onSessionStateChange(reason, error);
   }
 
   async _fetchUserInfo(accessToken?: string): Promise<UserInfo> {

--- a/packages/authgear-react-native/src/index.ts
+++ b/packages/authgear-react-native/src/index.ts
@@ -321,8 +321,11 @@ export class ReactNativeContainer {
    *
    * @internal
    */
-  onSessionStateChange(reason: SessionStateChangeReason): void {
-    this.delegate?.onSessionStateChange(this, reason);
+  onSessionStateChange(
+    reason: SessionStateChangeReason,
+    error?: unknown
+  ): void {
+    this.delegate?.onSessionStateChange(this, reason, error);
   }
 
   /**

--- a/packages/authgear-react-native/src/types.ts
+++ b/packages/authgear-react-native/src/types.ts
@@ -20,11 +20,16 @@ export interface ReactNativeContainerDelegate {
    * For example, when the user logs out, the new state is "NO_SESSION"
    * and the reason is "LOGOUT".
    *
+   * error is non-null when reason is "INVALID", i.e. the session was
+   * cleared because a request failed with an error such as invalid_grant
+   * or invalid_dpop_proof. It is undefined for all other reasons.
+   *
    * @public
    */
   onSessionStateChange: (
     container: ReactNativeContainer,
-    reason: SessionStateChangeReason
+    reason: SessionStateChangeReason,
+    error?: unknown
   ) => void;
 }
 

--- a/packages/authgear-web/src/container.ts
+++ b/packages/authgear-web/src/container.ts
@@ -242,8 +242,11 @@ export class WebContainer {
    *
    * @internal
    */
-  onSessionStateChange(reason: SessionStateChangeReason): void {
-    this.delegate?.onSessionStateChange(this, reason);
+  onSessionStateChange(
+    reason: SessionStateChangeReason,
+    error?: unknown
+  ): void {
+    this.delegate?.onSessionStateChange(this, reason, error);
   }
 
   /**

--- a/packages/authgear-web/src/types.ts
+++ b/packages/authgear-web/src/types.ts
@@ -15,11 +15,16 @@ export interface WebContainerDelegate {
    * For example, when the user logs out, the new state is "NO_SESSION"
    * and the reason is "LOGOUT".
    *
+   * error is non-null when reason is "INVALID", i.e. the session was
+   * cleared because a request failed with an error such as invalid_grant
+   * or invalid_dpop_proof. It is undefined for all other reasons.
+   *
    * @public
    */
   onSessionStateChange: (
     container: WebContainer,
-    reason: SessionStateChangeReason
+    reason: SessionStateChangeReason,
+    error?: unknown
   ) => void;
 }
 


### PR DESCRIPTION
ref DEV-3680

To test, you can follow the steps in the PR description:
- https://github.com/authgear/authgear-sdk-ios/pull/216

--- 

**Other note:**

In the Capacitor example app, `fetchUserInfo` is called immediately after configuration, so the `invalid_dpop_proof` error cannot be reproduced by default.

To reproduce the error, comment out the `fetchUserInfo` call in `postConfigure`. This allows you to call `refreshAccessTokenIfNeeded` directly to reproduce the dpop error.
